### PR TITLE
Fix removal of interaction animation

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/player/KeyboardPlayerInputComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/player/KeyboardPlayerInputComponent.java
@@ -51,6 +51,9 @@ public class KeyboardPlayerInputComponent extends InputComponent {
         case Keys.SHIFT_LEFT:
           entity.getEvents().trigger("run");
           return true;
+        case Keys.E: // Potentially also interact button later.
+          entity.getEvents().trigger("interact");
+          return true;
         case Keys.I:
           // inventory tings
           entity.getEvents().trigger("toggleInventory");


### PR DESCRIPTION
The keybinding for the interaction animation had been removed during a merge commit from another team. This restores the keybinding.