### PR TITLE
Implements setDay command

### DIFF
--- a/source/core/src/main/com/csse3200/game/ui/terminal/Terminal.java
+++ b/source/core/src/main/com/csse3200/game/ui/terminal/Terminal.java
@@ -3,6 +3,7 @@ package com.csse3200.game.ui.terminal;
 import com.csse3200.game.components.Component;
 import com.csse3200.game.ui.terminal.commands.Command;
 import com.csse3200.game.ui.terminal.commands.DebugCommand;
+import com.csse3200.game.ui.terminal.commands.SetDayCommand;
 import com.csse3200.game.ui.terminal.commands.SetTimeCommand;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +32,7 @@ public class Terminal extends Component {
 
     addCommand("debug", new DebugCommand());
     addCommand("setTime", new SetTimeCommand());
+    addCommand("setDay", new SetDayCommand());
   }
 
   /** @return message entered by user */

--- a/source/core/src/main/com/csse3200/game/ui/terminal/commands/SetDayCommand.java
+++ b/source/core/src/main/com/csse3200/game/ui/terminal/commands/SetDayCommand.java
@@ -1,0 +1,43 @@
+package com.csse3200.game.ui.terminal.commands;
+
+import com.csse3200.game.services.ServiceLocator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+
+public class SetDayCommand implements Command {
+
+  private static final Logger logger = LoggerFactory.getLogger(SetDayCommand.class);
+
+  /**
+   * Adjusts the current game time to the specified value
+   *
+   * @param args command args
+   * @return command was successful
+   */
+  @Override
+  public boolean action(ArrayList<String> args) {
+    if (!isValid(args)) {
+      logger.debug("Invalid arguments received for 'setDay' command: {}", args);
+      return false;
+    }
+    ServiceLocator.getTimeService().setDay(Integer.parseInt(args.get(0)));
+    return true;
+  }
+
+  Boolean isValid(ArrayList<String> args) {
+    if (args.size() != 1) {
+      logger.debug("Only 1 argument is needed and {} were given", args.size());
+      return false;
+    }
+    int day;
+    try {
+      day = Integer.parseInt(args.get(0));
+    } catch (NumberFormatException e) {
+      logger.debug("Argument provided was not a valid integer");
+      return false;
+    }
+	  return day >= 0;
+  }
+}

--- a/source/core/src/test/com/csse3200/game/ui/terminal/commands/SetDayCommandTest.java
+++ b/source/core/src/test/com/csse3200/game/ui/terminal/commands/SetDayCommandTest.java
@@ -1,0 +1,68 @@
+package com.csse3200.game.ui.terminal.commands;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.*;
+
+import com.csse3200.game.entities.EntityService;
+import com.csse3200.game.extensions.GameExtension;
+import com.csse3200.game.physics.PhysicsService;
+import com.csse3200.game.rendering.RenderService;
+import com.csse3200.game.services.ResourceService;
+import com.csse3200.game.services.ServiceLocator;
+import java.util.ArrayList;
+
+import com.csse3200.game.services.TimeService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+
+@ExtendWith(GameExtension.class)
+class SetDayCommandTest {
+
+	SetDayCommand command;
+	ArrayList<String> args;
+	@BeforeEach
+	void beforeEach() {
+		command = new SetDayCommand();
+		args = new ArrayList<>();
+	}
+
+	@Test
+	void testCommand() {
+
+		ServiceLocator.registerTimeService(mock(TimeService.class));
+
+		int day = 9;
+		args.add(String.valueOf(day));
+
+		command.action(args);
+		verify(ServiceLocator.getTimeService(), times(1)).setDay(day);
+	}
+
+	@Test
+	void testTooManyArgsValid() {
+		args.add("9");
+		args.add("9");
+		assertFalse(command.isValid(args));
+	}
+
+	@Test
+	void testTooManyArgsAction() {
+		args.add("9");
+		args.add("9");
+		assertFalse(command.action(args));
+	}
+
+	@Test
+	void invalidNumber() {
+		args.add("wrong");
+		assertFalse(command.isValid(args));
+	}
+
+	@Test
+	void noArgs() {
+		assertFalse(command.isValid(args));
+	}
+}


### PR DESCRIPTION
# Overview

This pull request implements the `setDay` command into the debug terminal allowing you to set the in-game day. This will be helpful when testing the game's lose condition. Closes #127 