### PR TITLE
215 Removes the registering of the crop tile entity in the TerrainCropTileFactory

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/terrain/TerrainCropTileFactory.java
+++ b/source/core/src/main/com/csse3200/game/areas/terrain/TerrainCropTileFactory.java
@@ -56,8 +56,6 @@ public class TerrainCropTileFactory {
 
 		tile.setPosition(position);
 		logger.debug("Registering crop tile {} with entity service", tile);
-		ServiceLocator.getEntityService().register(tile);
-
 		return tile;
 	}
 }

--- a/source/core/src/main/com/csse3200/game/areas/terrain/TerrainCropTileFactory.java
+++ b/source/core/src/main/com/csse3200/game/areas/terrain/TerrainCropTileFactory.java
@@ -55,7 +55,6 @@ public class TerrainCropTileFactory {
 				.addComponent(new CropTileComponent(stats.initialWaterContent, stats.initialSoilQuality));
 
 		tile.setPosition(position);
-		logger.debug("Registering crop tile {} with entity service", tile);
 		return tile;
 	}
 }


### PR DESCRIPTION
# Overview

Adjusts the `TerrainCropTileFactory` class so that it doesn't register the crop tile with the entity service.

Closes #215
 