### PR TITLE
Clearing ServiceLocator from MissionManager and Quest tests

### DIFF
--- a/source/core/src/test/com/csse3200/game/missions/MissionManagerTest.java
+++ b/source/core/src/test/com/csse3200/game/missions/MissionManagerTest.java
@@ -6,6 +6,7 @@ import com.csse3200.game.missions.rewards.Reward;
 import com.csse3200.game.services.GameTime;
 import com.csse3200.game.services.ServiceLocator;
 import com.csse3200.game.services.TimeService;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -125,6 +126,11 @@ class MissionManagerTest {
             protected void resetState() {
             }
         };
+    }
+
+    @AfterAll
+    public static void end() {
+        ServiceLocator.clear();
     }
 
     @Test

--- a/source/core/src/test/com/csse3200/game/missions/quests/QuestTest.java
+++ b/source/core/src/test/com/csse3200/game/missions/quests/QuestTest.java
@@ -6,6 +6,7 @@ import com.csse3200.game.missions.rewards.Reward;
 import com.csse3200.game.services.GameTime;
 import com.csse3200.game.services.ServiceLocator;
 import com.csse3200.game.services.TimeService;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -206,6 +207,11 @@ class QuestTest {
                 return "At: " + count;
             }
         };
+    }
+
+    @AfterAll
+    public static void end() {
+        ServiceLocator.clear();
     }
 
     @Test


### PR DESCRIPTION
Clearing ServiceLocator from MissionManager and Quest tests, to prevent testing issues as per Discord message in programming-committee.