### PR TITLE
Reducing maintainence requirement of SaveLoadService.java

### DIFF
--- a/source/core/src/main/com/csse3200/game/files/SaveGame.java
+++ b/source/core/src/main/com/csse3200/game/files/SaveGame.java
@@ -88,7 +88,8 @@ public class SaveGame {
 
     /**
      * Filter out all entities that are in the NPC Factory, player or tractor. THis
-     * function is mainly for SaveLoadService.java
+     * function is mainly for SaveLoadService.java. Produces a Array of entities
+     * from the NPC factory that needs to be remade
      * 
      * @param entities the entities to filter in Array<Entity>
      * @return the entities filtered in Array<Entity> for use in SaveLoadService.

--- a/source/core/src/main/com/csse3200/game/files/SaveGame.java
+++ b/source/core/src/main/com/csse3200/game/files/SaveGame.java
@@ -8,7 +8,6 @@ import com.csse3200.game.files.FileLoader.Location;
 
 import java.io.File;
 
-
 /**
  * Reading, Writing, and applying user settings in the game.
  */
@@ -18,6 +17,7 @@ public class SaveGame {
 
   /**
    * Get the stored save file
+   * 
    * @return Copy of the saved game state
    */
   public static GameState get() {
@@ -28,6 +28,7 @@ public class SaveGame {
 
   /**
    * Set the current game state
+   * 
    * @param gameState The gameState to store
    */
   public static void set(GameState gameState) {
@@ -50,7 +51,8 @@ public class SaveGame {
 
     private Array<Entity> tiles;
 
-    public GameState() {};
+    public GameState() {
+    };
 
     public int getDay() {
       return day;
@@ -79,18 +81,27 @@ public class SaveGame {
     public Array<Entity> getEntities() {
       return entities;
     }
-  
+
     public void setEntities(Array<Entity> entities) {
       this.entities = filterEntities(entities);
     }
 
+    /**
+     * Filter out all entities that are in the NPC Factory, player or tractor. THis
+     * function is mainly for SaveLoadService.java
+     * 
+     * @param entities the entities to filter in Array<Entity>
+     * @return the entities filtered in Array<Entity> for use in SaveLoadService.
+     */
     private Array<Entity> filterEntities(Array<Entity> entities) {
       // If you edit this original array you edit what is in the ResourceService
       Array<Entity> tmp = new Array<>(entities);
       for (int i = 0; i < tmp.size; i++) {
-        if (tmp.get(i).getType() == EntityType.Item || tmp.get(i).getType() == EntityType.Player || tmp.get(i).getType() == null
-                || tmp.get(i).getType() == EntityType.Tractor || tmp.get(i).getType() == EntityType.Tile
-                || tmp.get(i).getType() == EntityType.Questgiver || tmp.get(i).getType() == EntityType.QuestgiverIndicator || tmp.get(i).getType() == EntityType.Plant) {
+        if (tmp.get(i).getType() == EntityType.Item || tmp.get(i).getType() == EntityType.Player
+            || tmp.get(i).getType() == null
+            || tmp.get(i).getType() == EntityType.Tractor || tmp.get(i).getType() == EntityType.Tile
+            || tmp.get(i).getType() == EntityType.Questgiver || tmp.get(i).getType() == EntityType.QuestgiverIndicator
+            || tmp.get(i).getType() == EntityType.Plant) {
           tmp.removeIndex(i);
           // Moves the indexing down when removed so keep index same
           i--;
@@ -104,11 +115,13 @@ public class SaveGame {
     }
 
     /**
-     * Loop through all entities in the save file and if the tractor is there return the tractor
-     *    if not return null
+     * Loop through all entities in the save file and if the tractor is there return
+     * the tractor
+     * if not return null
+     * 
      * @return
      */
-    public Entity getTractor(){
+    public Entity getTractor() {
       return tractor;
     }
 

--- a/source/core/src/main/com/csse3200/game/files/SaveGame.java
+++ b/source/core/src/main/com/csse3200/game/files/SaveGame.java
@@ -87,7 +87,7 @@ public class SaveGame {
     }
 
     /**
-     * Filter out all entities that are in the NPC Factory, player or tractor. THis
+     * Filter out all entities that are in the NPC Factory, player or tractor. This
      * function is mainly for SaveLoadService.java. Produces a Array of entities
      * from the NPC factory that needs to be remade
      * 
@@ -96,16 +96,11 @@ public class SaveGame {
      */
     private Array<Entity> filterEntities(Array<Entity> entities) {
       // If you edit this original array you edit what is in the ResourceService
-      Array<Entity> tmp = new Array<>(entities);
-      for (int i = 0; i < tmp.size; i++) {
-        if (tmp.get(i).getType() == EntityType.Item || tmp.get(i).getType() == EntityType.Player
-            || tmp.get(i).getType() == null
-            || tmp.get(i).getType() == EntityType.Tractor || tmp.get(i).getType() == EntityType.Tile
-            || tmp.get(i).getType() == EntityType.Questgiver || tmp.get(i).getType() == EntityType.QuestgiverIndicator
-            || tmp.get(i).getType() == EntityType.Plant) {
-          tmp.removeIndex(i);
-          // Moves the indexing down when removed so keep index same
-          i--;
+      Array<Entity> tmp = new Array<>();
+      for (Entity e : entities) {
+        if (e.getType() == EntityType.Astrolotl || e.getType() == EntityType.Chicken ||
+                e.getType() == EntityType.Cow || e.getType() == EntityType.OxygenEater) {
+          tmp.add(e);
         }
       }
       return tmp;

--- a/source/core/src/test/com/csse3200/game/entities/EntityTypeTest.java
+++ b/source/core/src/test/com/csse3200/game/entities/EntityTypeTest.java
@@ -32,7 +32,7 @@ public class EntityTypeTest {
    * needs to be loaded into the game.
    * any components need write functions implemented.
    * after you complete that you can add the working enum
-   * type to the list of approved enums below
+   * type to the list of approved enums at the top of this
    * this is all in the documentation at
    * https://github.com/UQcsse3200/2023-studio-1/wiki/Save---Load-game
    * at the bottom
@@ -57,7 +57,7 @@ public class EntityTypeTest {
    * needs to be loaded into the game.
    * any components need write functions implemented.
    * after you complete that you can add the working enum
-   * type to the list of approved enums below
+   * type to the list of approved enums at the top of this
    * this is all in the documentation at
    * https://github.com/UQcsse3200/2023-studio-1/wiki/Save---Load-game
    * at the bottom

--- a/source/core/src/test/com/csse3200/game/entities/EntityTypeTest.java
+++ b/source/core/src/test/com/csse3200/game/entities/EntityTypeTest.java
@@ -1,0 +1,84 @@
+package com.csse3200.game.entities;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class EntityTypeTest {
+  EntityType[] enumValues;
+  Set<String> expectedEnumNames;
+
+  @BeforeEach
+  public void setUp() {
+    enumValues = EntityType.values();
+
+    // Expected enum names.
+    // https://github.com/UQcsse3200/2023-studio-1/wiki/Save---Load-game
+    expectedEnumNames = new HashSet<>(Arrays.asList(
+        "Player", "Tractor", "Plant", "Tile", "Cow",
+        "Chicken", "Astrolotl", "OxygenEater", "Item",
+        "Questgiver", "QuestgiverIndicator"));
+
+  }
+
+  /*
+   * If you are failing this below test you didn't follow the documentation
+   * from t1 about adding new enum types. you must add
+   * new enum values to factoryService if it
+   * needs to be loaded into the game.
+   * any components need write functions implemented.
+   * after you complete that you can add the working enum
+   * type to the list of approved enums below
+   * this is all in the documentation at
+   * https://github.com/UQcsse3200/2023-studio-1/wiki/Save---Load-game
+   * at the bottom
+   * 
+   */
+
+  @Test
+  public void testEnumValuesAddedFollowedProcedure() {
+
+    for (EntityType enumValue : enumValues) {
+      if (!expectedEnumNames.contains(enumValue.name())) {
+        fail("Enum value '" + enumValue.name()
+            + "' is not recognized. Please view https://github.com/UQcsse3200/2023-studio-1/wiki/Save---Load-game for instructions.");
+      }
+    }
+  }
+
+  /*
+   * If you are failing this below test you didn't follow the documentation
+   * from t1 about adding new enum types. you must add
+   * new enum values to factoryService if it
+   * needs to be loaded into the game.
+   * any components need write functions implemented.
+   * after you complete that you can add the working enum
+   * type to the list of approved enums below
+   * this is all in the documentation at
+   * https://github.com/UQcsse3200/2023-studio-1/wiki/Save---Load-game
+   * at the bottom
+   * 
+   */
+
+  @Test
+  public void testEnumValuesRemovedFollowedProcedure() {
+
+    // Check if any expected enum names are missing.
+    for (String expectedEnumName : expectedEnumNames) {
+      boolean found = false;
+      for (EntityType enumValue : enumValues) {
+        if (enumValue.name().equals(expectedEnumName)) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        fail("Expected enum value '" + expectedEnumName + "' is missing.");
+      }
+    }
+  }
+}


### PR DESCRIPTION
#290 
https://github.com/UQcsse3200/2023-studio-1/wiki/Save---Load-game

SaveLoadService breaks everytime someone adds or unexpectedly removes an EntityType.

Implemented junit test  to detect improper setup of new EntityType. ALso fixed dependency of filterEntities function