### PR TITLE
Test game launches

### DIFF
--- a/.github/workflows/gradle_tests.yaml
+++ b/.github/workflows/gradle_tests.yaml
@@ -6,7 +6,7 @@ jobs:
   run_unit_tests:
     runs-on: ubuntu-latest # Running on this OS, if we need it changed lmk
     steps:
-      - uses: actions/checkout@v2 # Checkout repo to remote machine
+      - uses: actions/checkout@v3 # Checkout repo to remote machine
       - name: Set up OpenJDK17 
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/launch_tests.yaml
+++ b/.github/workflows/launch_tests.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Run Launch Test
         id: tests # Unique ID to reference later to color our message
         run: |
-          sudo apt install xvfb
+          sudo apt install -y xdotool x11-apps
           cd $GRADLE_DIR
           chmod +x ./gradlew
           chmod +x ./headless_run.sh

--- a/.github/workflows/launch_tests.yaml
+++ b/.github/workflows/launch_tests.yaml
@@ -13,10 +13,10 @@ jobs:
           java-version: '17'
 
       - name: Run Launch Test
-        uses: coactions/setup-xvfb@v1
         id: tests # Unique ID to reference later to color our message
         with:
           run: |
+            sudo apt install xvfb
             cd $GRADLE_DIR
             chmod +x ./gradlew
             chmod +x ./headless_run.sh

--- a/.github/workflows/launch_tests.yaml
+++ b/.github/workflows/launch_tests.yaml
@@ -14,13 +14,12 @@ jobs:
 
       - name: Run Launch Test
         id: tests # Unique ID to reference later to color our message
-        with:
-          run: |
-            sudo apt install xvfb
-            cd $GRADLE_DIR
-            chmod +x ./gradlew
-            chmod +x ./headless_run.sh
-            ./headless_run.sh
+        run: |
+          sudo apt install xvfb
+          cd $GRADLE_DIR
+          chmod +x ./gradlew
+          chmod +x ./headless_run.sh
+          ./headless_run.sh
         env:
           GRADLE_DIR: 'source' # Modify this to wherever './gradlew' is 
       - name: Archive game screenshot

--- a/.github/workflows/launch_tests.yaml
+++ b/.github/workflows/launch_tests.yaml
@@ -1,0 +1,56 @@
+name: Launch Tests
+
+on: [push, pull_request] # Will trigger whenever a push is made to the branch, regardless of which branch
+
+jobs:
+  run_unit_tests:
+    runs-on: ubuntu-latest # Running on this OS, if we need it changed lmk
+    steps:
+      - uses: actions/checkout@v2 # Checkout repo to remote machine
+      - name: Set up OpenJDK17 
+        uses: actions/setup-java@v1
+        with:
+          java-version: '17'
+
+      - name: Run Launch Test
+        uses: coactions/setup-xvfb@v1
+        id: tests # Unique ID to reference later to color our message
+        with:
+          run: |
+            cd $GRADLE_DIR
+            chmod +x ./gradlew
+            chmod +x ./headless_run.sh
+            ./headless_run.sh
+        env:
+          GRADLE_DIR: 'source' # Modify this to wherever './gradlew' is 
+      - name: Archive game screenshot
+        uses: actions/upload-artifact@v3
+        with:
+          name: game-screenshot
+          path: source/game_launched.xwd
+      - name: Test Success
+        uses: rjstone/discord-webhook-notify@v1
+        if: success()
+        with:
+           severity: info
+           username: GitHub
+           details: Test Succeeded!
+           webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
+
+      - name: Test Failure
+        uses: rjstone/discord-webhook-notify@v1
+        if: failure()
+        with:
+           severity: error
+           username: GitHub
+           details: Test Failed!
+           webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
+           
+      - name: Test Cancelled
+        uses: rjstone/discord-webhook-notify@v1
+        if: cancelled()
+        with:
+           severity: warn
+           username: GitHub
+           details: Test Cancelled!
+           webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/launch_tests.yaml
+++ b/.github/workflows/launch_tests.yaml
@@ -6,7 +6,7 @@ jobs:
   run_unit_tests:
     runs-on: ubuntu-latest # Running on this OS, if we need it changed lmk
     steps:
-      - uses: actions/checkout@v2 # Checkout repo to remote machine
+      - uses: actions/checkout@v3 # Checkout repo to remote machine
       - name: Set up OpenJDK17 
         uses: actions/setup-java@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 ### Gradle ###
 .gradle/
+gradle/*.log

--- a/source/headless_run.sh
+++ b/source/headless_run.sh
@@ -21,7 +21,8 @@ pkill -P $$
 # Check if run was successful
 grep Exception game.log
 if [ $? -eq 1 ]; then
-  echo "Run failed. Last 30 lines of log:"
+  echo "Run failed. If this is unexpected, see https://github.com/UQcsse3200/2023-studio-1/wiki/Launch-Testing#my-commits-fail-this-test-and-i-dont-know-why"
+  echo "Last 30 lines of log:"
   tail -30 game.log
   OUTPUT_VAL=1
 else

--- a/source/headless_run.sh
+++ b/source/headless_run.sh
@@ -1,0 +1,32 @@
+Xvfb :1 & # Create an X server to a virtual framebuffer
+XVFB_PID=$!
+
+DISPLAY=:1 ./gradlew clean run 2>game.log 1>gradle.log &
+GAME_PID=$!
+
+sleep 35 # Give the game some time to launch
+
+# Click 640,417 to start new game and then 640,790 to skip the intro sequence
+DISPLAY=:1 xdotool mousemove 640 417 click 1 # Click 'New Game' 
+
+sleep 10
+DISPLAY=:1 xdotool mousemove 640 790 click 1 # Click 'Continue'
+
+sleep 35
+DISPLAY=:1 xwd -root -out game_launched.xwd
+
+# Clean up 
+pkill -P $$
+
+# Check if run was successful
+grep Exception game.log
+if [ $? -eq 1 ]; then
+  echo "Run failed. Last 30 lines of log:"
+  tail -30 game.log
+  OUTPUT_VAL=1
+else
+  OUTPUT_VAL=0
+fi
+
+rm game.log gradle.log
+exit ${OUTPUT_VAL}


### PR DESCRIPTION
This is copied mostly verbatim from the [Discord channel](https://discord.com/channels/1131850017188102195/1151781249107628062/1151786322848133160).

I've created a new test (that is separate from unit tests) and simply checks that the game can be launched and a new game can be created. This means it should have been able to catch each of the times `main` was broken on Tuesday, but it would **not** catch anything that requires user input (such as the crash on pause #286, crash on interact #283, etc) or related to save/load, settings, etc.

This script is **not** run as part of gradle's tests - you can run it by using the `source/headless_run.sh` script though. You will need to have the `xvfb`, `xdotool` and `x11-apps` packages installed if you are on Debian.

There's a few more caveats that I see:

- The test injects mouse clicks at specific locations. If these change, or if the game's handling of lower resolutions changes, then the test will need to be updated.
- The UI and start sequences must not get (much) slower than they are currently, for the same reason - otherwise the test may kill the game before it loads fully if it becomes slower
- The [screenshot it uploads - found in artifacts section](https://github.com/UQcsse3200/2023-studio-1/actions/runs/6181710057) is an .xwd file. This is openable in GIMP, not sure about other software

The code for this is on the `test-game-launches` branch ([link](https://github.com/UQcsse3200/2023-studio-1/tree/test-game-launches)) and I'd appreciate if people had a look.

This is a small change code-wise, but it does have potential to cause issues down the line in any edge cases I've not considered, which is why I'm asking everyone for feedback and to take a look at the implementation.