### PR TITLE
Hoe fix

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/items/ItemActions.java
+++ b/source/core/src/main/com/csse3200/game/components/items/ItemActions.java
@@ -237,7 +237,7 @@ public class ItemActions extends Component {
    */
   private boolean hoe(Vector2 playerPos, Vector2 mousePos) {
     TerrainTile tile = getTileAtPosition(playerPos, mousePos);
-    if (tile.getCropTile() != null || !tile.isTillable()) {
+    if (tile.isOccupied() || !tile.isTillable()) {
       return false;
     }
     // Make a new tile


### PR DESCRIPTION
Was able to hoe tiles that had a placeable object on them, this should code should stop this from occurring by checking if the tile is occupied instead of just checking for a crop tile.