### PR TITLE
Fix launch test inverted result 

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
@@ -104,7 +104,7 @@ public class SpaceGameArea extends GameArea {
           "images/fertiliser.png",
 
           "images/plants/misc/aloe_vera_seed.png",
-          "images/plants/misc/atomic_algae_seed.png",
+          "images/plants/atomic_algae/1_seedling.png",
           "images/plants/misc/cosmic_cob_seed.png",
           "images/plants/misc/deadly_nightshade_seed.png",
           "images/plants/misc/hammer_plant_seed.png",

--- a/source/core/src/main/com/csse3200/game/entities/factories/ItemFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/ItemFactory.java
@@ -167,9 +167,9 @@ public class ItemFactory {
    */
   public static Entity createAtomicAlgaeSeed() {
     Entity seed = createBaseItem()
-            .addComponent(new TextureRenderComponent("images/plants/misc/atomic_algae_seed.png"))
+            .addComponent(new TextureRenderComponent("images/plants/atomic_algae/1_seedling.png"))
             .addComponent(new ItemComponent("atomic algae seed", ItemType.SEED,
-                    "Seed of Atomic Algae", new Texture("images/plants/misc/atomic_algae_seed.png")));
+                    "Seed of Atomic Algae", new Texture("images/plants/atomic_algae/1_seedling.png")));
     return seed;
   }
 

--- a/source/headless_run.sh
+++ b/source/headless_run.sh
@@ -20,7 +20,7 @@ pkill -P $$
 
 # Check if run was successful
 grep Exception game.log
-if [ $? -eq 1 ]; then
+if [ $? -eq 0 ]; then
   echo "Run failed. If this is unexpected, see https://github.com/UQcsse3200/2023-studio-1/wiki/Launch-Testing#my-commits-fail-this-test-and-i-dont-know-why"
   echo "Last 30 lines of log:"
   tail -30 game.log


### PR DESCRIPTION
The launch test was inverting the results - it passed if an exception was found and fails if none is found. This PR fixes this issue.

It also fixes the bug that made this non-obvious during development - a texture which is no longer packaged was being referenced. This has been changed to the closest available texture as a placeholder - expected to be changed at a later point.