### PR TITLE
Ship Progress Component

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
@@ -39,7 +39,7 @@ public class SpaceGameArea extends GameArea {
   private static final GridPoint2 PLAYER_SPAWN = new GridPoint2(10, 10);
   private static final GridPoint2 QUESTGIVER_SPAWN = new GridPoint2(20, 20);
   private static final GridPoint2 SHIP_SPAWN = new GridPoint2(50,50);
-  private static final GridPoint2 QUESTGIVERIND_SPAWN = new GridPoint2(20, 22);
+
   private static final GridPoint2 TRACTOR_SPAWN = new GridPoint2(15, 15);
 
   private static final GridPoint2 TOOL_SPAWN = new GridPoint2(15, 10);// temp!!!
@@ -342,7 +342,7 @@ public class SpaceGameArea extends GameArea {
     spawnEntityAt(newQuestgiver, QUESTGIVER_SPAWN, true, true);
 
     Entity newQuestgiverIndicator = QuestgiverFactory.createQuestgiverIndicator(newQuestgiver);
-    spawnEntityAt(newQuestgiverIndicator, QUESTGIVERIND_SPAWN, true, true);
+    spawnEntityAt(newQuestgiverIndicator, new GridPoint2(QUESTGIVER_SPAWN.x, QUESTGIVER_SPAWN.y+2), true, true);
   }
 
   private void spawnShip() {

--- a/source/core/src/main/com/csse3200/game/components/ship/ShipProgressComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/ship/ShipProgressComponent.java
@@ -34,7 +34,7 @@ public class ShipProgressComponent extends Component {
         this.progress = 0;
         unlocked_features = new HashSet<Feature>();
         // listen to add artefact call
-        entity.getEvents().addListener("addArtefact", this::incrementProgress);
+        entity.getEvents().addListener("addPart", this::incrementProgress);
     }
 
     /**

--- a/source/core/src/main/com/csse3200/game/components/ship/ShipProgressComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/ship/ShipProgressComponent.java
@@ -1,0 +1,43 @@
+package com.csse3200.game.components.ship;
+
+import com.csse3200.game.components.Component;
+
+import static java.lang.Math.min;
+
+public class ShipProgressComponent extends Component {
+    static int maximum_repair = 20;
+    private int progress;
+
+    /**
+     * This component will handle the Ship's internal state of repair. It will listen for addPart events on the Ship
+     * Entity, which will pass the number of Ship Part Items the player is using on the ship, and increment its
+     * internal state of repair by that amount. It will also trigger a progressUpdated event on the Ship Entity along
+     * with the current state of repair for other components to use.
+     */
+    @Override
+    public void create() {
+        this.progress = 0;
+        // listen to add artefact call
+        entity.getEvents().addListener("addArtefact", this::incrementProgress);
+    }
+
+    /**
+     * Update the progress of the ship repair by incrementing it by however many artefacts the player 'used' on the
+     * ship. This will also call a progressUpdate event on the Ship entity it is attached to.
+     */
+    private void incrementProgress(int amount) {
+        if (this.progress < maximum_repair) {
+            // Bound maximum repair state
+            this.progress = min(this.progress + amount, maximum_repair);
+            // TODO: Only send progress update if repair actually happened
+        }
+    }
+
+    /**
+     * Update the progress of the ship's repair by decrementing it - this would be used by the bonus shipeater entity.
+     */
+    private void decrementProgress(int amount) {
+        // Bound progress to being no less than 0
+        this.progress -= Math.max(progress, 0);
+    }
+}

--- a/source/core/src/main/com/csse3200/game/entities/factories/ShipFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/ShipFactory.java
@@ -3,6 +3,7 @@ package com.csse3200.game.entities.factories;
 import com.badlogic.gdx.graphics.g2d.Animation;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.physics.box2d.BodyDef.BodyType;
+import com.csse3200.game.components.ship.ShipProgressComponent;
 import com.csse3200.game.entities.Entity;
 import com.csse3200.game.entities.EntityType;
 import com.csse3200.game.physics.components.ColliderComponent;
@@ -27,6 +28,7 @@ public class ShipFactory {
         .addComponent(new PhysicsComponent())
         .addComponent(new PhysicsMovementComponent())
         .addComponent(new ColliderComponent())
+        .addComponent(new ShipProgressComponent())
         .addComponent(animator);
 
     ship.getComponent(AnimationRenderComponent.class).scaleEntity();


### PR DESCRIPTION
Implements the ShipProgressComponent which keeps track of the state of repair and what features are unlocked (currently available: bed, light, chest/storage). Includes provisions for decrementing progress if the bonus shipeater is implemented.

Also includes a minor change so that the questgiver indicator position is based upon the Questgiver's location