### PR TITLE
#349 Implemented `ShipTimeSkipComponent`

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/ship/ShipTimeSkipComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/ship/ShipTimeSkipComponent.java
@@ -15,11 +15,13 @@ import java.util.Set;
 public class ShipTimeSkipComponent extends Component {
     private static final Logger logger = LoggerFactory.getLogger(ShipTimeSkipComponent.class);
     private boolean unlocked;
+    private boolean timeSkipInProgress;
 
     @Override
     public void create() {
         super.create();
         unlocked = false;
+        timeSkipInProgress = false;
 
         entity.getEvents().addListener("progressUpdated", this::progressUpdated);
         entity.getEvents().addListener("interact", this::triggerTimeSkip);
@@ -47,10 +49,15 @@ public class ShipTimeSkipComponent extends Component {
         if (unlocked) {
             logger.debug("Skipping time to next MORNING_HOUR");
             ServiceLocator.getTimeSource().setTimeScale(200f);
+            timeSkipInProgress = true;
         }
     }
 
     private void stopTimeSkip() {
-        ServiceLocator.getTimeSource().setTimeScale(1f);
+        // Don't do anything if the morningTime event was triggered, but we're not sleeping
+        if (timeSkipInProgress) {
+            ServiceLocator.getTimeSource().setTimeScale(1f);
+            timeSkipInProgress = false;
+        }
     }
 }

--- a/source/core/src/main/com/csse3200/game/components/ship/ShipTimeSkipComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/ship/ShipTimeSkipComponent.java
@@ -8,8 +8,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Set;
 
-import static com.csse3200.game.services.TimeService.MORNING_HOUR;
-
 /**
  * Handles allowing the player to sleep through the night by interacting
  * with the ship once the repair threshold is reached.
@@ -25,6 +23,8 @@ public class ShipTimeSkipComponent extends Component {
 
         entity.getEvents().addListener("progressUpdated", this::progressUpdated);
         entity.getEvents().addListener("interact", this::triggerTimeSkip);
+
+        ServiceLocator.getTimeService().getEvents().addListener("morningTime", this::stopTimeSkip);
     }
 
     /**
@@ -46,7 +46,11 @@ public class ShipTimeSkipComponent extends Component {
     private void triggerTimeSkip() {
         if (unlocked) {
             logger.debug("Skipping time to next MORNING_HOUR");
-            ServiceLocator.getTimeService().setNearestTime(MORNING_HOUR);
+            ServiceLocator.getTimeSource().setTimeScale(100f);
         }
+    }
+
+    private void stopTimeSkip() {
+        ServiceLocator.getTimeSource().setTimeScale(1f);
     }
 }

--- a/source/core/src/main/com/csse3200/game/components/ship/ShipTimeSkipComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/ship/ShipTimeSkipComponent.java
@@ -46,7 +46,7 @@ public class ShipTimeSkipComponent extends Component {
     private void triggerTimeSkip() {
         if (unlocked) {
             logger.debug("Skipping time to next MORNING_HOUR");
-            ServiceLocator.getTimeSource().setTimeScale(100f);
+            ServiceLocator.getTimeSource().setTimeScale(200f);
         }
     }
 

--- a/source/core/src/main/com/csse3200/game/components/ship/ShipTimeSkipComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/ship/ShipTimeSkipComponent.java
@@ -1,0 +1,52 @@
+package com.csse3200.game.components.ship;
+
+import com.csse3200.game.components.Component;
+import com.csse3200.game.components.ship.ShipProgressComponent.Feature;
+import com.csse3200.game.services.ServiceLocator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+import static com.csse3200.game.services.TimeService.MORNING_HOUR;
+
+/**
+ * Handles allowing the player to sleep through the night by interacting
+ * with the ship once the repair threshold is reached.
+ */
+public class ShipTimeSkipComponent extends Component {
+    private static final Logger logger = LoggerFactory.getLogger(ShipTimeSkipComponent.class);
+    private boolean unlocked;
+
+    @Override
+    public void create() {
+        super.create();
+        unlocked = false;
+
+        entity.getEvents().addListener("progressUpdated", this::progressUpdated);
+        entity.getEvents().addListener("interact", this::triggerTimeSkip);
+    }
+
+    /**
+     * If the BED feature has been unlocked on the Ship Entity, set own state to unlocked
+     *
+     * @param repairsMade number of repairs on the Ship Entity
+     * @param unlockedFeatures features that have been unlocked on the Ship Entity
+     */
+    private void progressUpdated(int repairsMade, Set<Feature> unlockedFeatures) {
+        if (unlockedFeatures.contains(Feature.BED)) {
+            logger.debug("Ship TimeSkip unlocked");
+            unlocked = true;
+        }
+    }
+
+    /**
+     * If time skip is unlocked, trigger the sleep function on the time service.
+     */
+    private void triggerTimeSkip() {
+        if (unlocked) {
+            logger.debug("Skipping time to next MORNING_HOUR");
+            ServiceLocator.getTimeService().setNearestTime(MORNING_HOUR);
+        }
+    }
+}

--- a/source/core/src/main/com/csse3200/game/entities/factories/PlayerFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/PlayerFactory.java
@@ -71,7 +71,7 @@ public class PlayerFactory {
             .addComponent(new PlayerAnimationController())
             .addComponent(new ItemPickupComponent())
             .addComponent(new InteractionDetector(2f, new ArrayList<EntityType>(Arrays.asList(EntityType.Questgiver, EntityType.Gate, EntityType.Chest, EntityType.Chicken,
-                    EntityType.Cow, EntityType.Astrolotl, EntityType.OxygenEater, EntityType.ShipDebris))))
+                    EntityType.Cow, EntityType.Astrolotl, EntityType.OxygenEater, EntityType.ShipDebris, EntityType.Ship))))
             .addComponent(new ToolbarDisplay())
 	        .addComponent(new AuraLightComponent(6f))
             .addComponent(new InventoryDisplay(playerInventory))

--- a/source/core/src/main/com/csse3200/game/entities/factories/ShipFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/ShipFactory.java
@@ -5,9 +5,11 @@ import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.physics.box2d.BodyDef.BodyType;
 import com.csse3200.game.components.ship.ShipAnimationController;
 import com.csse3200.game.components.ship.ShipProgressComponent;
+import com.csse3200.game.components.ship.ShipTimeSkipComponent;
 import com.csse3200.game.entities.Entity;
 import com.csse3200.game.entities.EntityType;
 import com.csse3200.game.physics.components.ColliderComponent;
+import com.csse3200.game.physics.components.HitboxComponent;
 import com.csse3200.game.physics.components.PhysicsComponent;
 import com.csse3200.game.physics.components.PhysicsMovementComponent;
 import com.csse3200.game.rendering.AnimationRenderComponent;
@@ -17,7 +19,7 @@ public class ShipFactory {
 
   /**
    * Creates a ship entity
-   * 
+   *
    * @return ship entity
    */
   public static Entity createShip() {
@@ -28,8 +30,10 @@ public class ShipFactory {
         .addComponent(new PhysicsComponent())
         .addComponent(new PhysicsMovementComponent())
         .addComponent(new ColliderComponent())
+        .addComponent(new HitboxComponent())
         .addComponent(new ShipProgressComponent())
         .addComponent(new ShipAnimationController())
+        .addComponent(new ShipTimeSkipComponent())
         .addComponent(animator);
 
     ship.getComponent(AnimationRenderComponent.class).scaleEntity();

--- a/source/core/src/main/com/csse3200/game/services/TimeService.java
+++ b/source/core/src/main/com/csse3200/game/services/TimeService.java
@@ -9,15 +9,19 @@ import com.csse3200.game.events.EventHandler;
 
 public class TimeService {
 	private static final Logger logger = LoggerFactory.getLogger(TimeService.class);
-	private static final int MS_IN_MINUTE = 500;
-	private static final int MORNING_HOUR = 6;
-	private static final int NIGHT_HOUR = 20;
+
 	private int minute;
 	private int hour;
 	private int day;
+
 	private long timeBuffer;
 	private boolean paused;
 	private final EventHandler events;
+
+	private static final int MS_IN_MINUTE = 500;
+
+	public static final int MORNING_HOUR = 6;
+	public static final int NIGHT_HOUR = 20;
 
 
 	/**
@@ -130,6 +134,42 @@ public class TimeService {
 		logger.debug("Minute is being set to: {}", this.minute);
 		this.timeBuffer = 0;
 		events.trigger("minuteUpdate");
+	}
+
+	/**
+	 * Sets the in-game hour to the nearest future hour passed in, rounded to 0 minutes.
+	 * Increments the day if necessary, updates the time buffer, and triggers any necessary events.
+	 *
+	 * @param hour in-game hour
+	 */
+	public void setNearestTime(int hour) {
+		setNearestTime(hour, 0);
+	}
+
+	/**
+	 * Sets the in-game hour and minute to the nearest future value passed in.
+	 * Increments the day if necessary, updates the time buffer, and triggers any necessary events.
+	 *
+	 * @param hour in-game hour
+	 * @param minute in-game minute
+ 	*/
+	public void setNearestTime(int hour, int minute) {
+		if (this.minute > minute) {
+			this.hour += 1;
+		}
+		this.minute = minute;
+		events.trigger("minuteUpdate");
+
+		if (this.hour > hour) {
+			this.day += 1;
+			events.trigger("dayUpdate");
+		}
+		this.hour = hour;
+		events.trigger("hourUpdate");
+
+		this.timeBuffer = 0;
+
+		logger.debug("Time is being set to: {}d, {}h, {}m", this.day, this.hour, this.minute);
 	}
 
 	/**

--- a/source/core/src/main/com/csse3200/game/services/TimeService.java
+++ b/source/core/src/main/com/csse3200/game/services/TimeService.java
@@ -2,10 +2,9 @@ package com.csse3200.game.services;
 
 import com.badlogic.gdx.utils.Json;
 import com.badlogic.gdx.utils.JsonValue;
+import com.csse3200.game.events.EventHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.csse3200.game.events.EventHandler;
 
 public class TimeService {
 	private static final Logger logger = LoggerFactory.getLogger(TimeService.class);
@@ -20,8 +19,8 @@ public class TimeService {
 
 	private static final int MS_IN_MINUTE = 500;
 
-	public static final int MORNING_HOUR = 6;
-	public static final int NIGHT_HOUR = 20;
+	private static final int MORNING_HOUR = 6;
+	private static final int NIGHT_HOUR = 20;
 
 
 	/**
@@ -182,6 +181,23 @@ public class TimeService {
 	}
 
 	/**
+	 * Trigger relevant events once the hour has been updated.
+	 */
+	private void triggerHourEvents() {
+		if (hour == MORNING_HOUR) {
+			// Made this an event so other entities can listen
+			logger.debug("Now night time");
+			events.trigger("morningTime");
+		} else if (hour == NIGHT_HOUR) {
+			logger.debug("Now morning time");
+			events.trigger("nightTime");
+		}
+
+		// Always trigger an hour update event
+		events.trigger("hourUpdate");
+	}
+
+	/**
 	 * Tracks the in-game time stored in the time service. This method is called in the main game loop. It calculates
 	 * the time that has passed since it last checked the time and calculates whether in-game time has elapsed.
 	 */
@@ -196,38 +212,38 @@ public class TimeService {
 		if (timeBuffer < MS_IN_MINUTE) {
 			return;
 		}
-		minute += 1;
-		timeBuffer -= MS_IN_MINUTE;
+
+		int minutesPassed = (int) (timeBuffer / MS_IN_MINUTE);
+		minute += minutesPassed;
+		timeBuffer -= ((long) minutesPassed * MS_IN_MINUTE);
 
 		// If minute is between 0 and 59, hour hasn't elapsed - don't do anything
 		if (minute < 60) {
 			events.trigger("minuteUpdate");
 			return;
 		}
-		logger.debug("In-game hour just passed");
-		hour += 1;
-		minute -= 60;
-		events.trigger("minuteUpdate");
 
-		if (hour == MORNING_HOUR) {
-			// Made this an event so other entities can listen
-			logger.debug("Now night time");
-			events.trigger("morningTime");
-		} else if (hour == NIGHT_HOUR) {
-			logger.debug("Now morning time");
-			events.trigger("nightTime");
-		}
+		logger.debug("In-game hour has updated");
+
+		int hoursPassed = minute / 60;
+		hour += hoursPassed;
+		minute -= (hoursPassed * 60);
+		events.trigger("minuteUpdate");
 
 		// If hour is between 0 and 23, day hasn't elapsed, do nothing
 		if (hour < 24) {
-			events.trigger("hourUpdate");
+			triggerHourEvents();
 			return;
 		}
-		logger.debug("In-game day just passed");
-		hour -= 24;
-		day += 1;
+
+		logger.debug("In-game day has updated");
+
+		int daysPassed = hour / 24;
+		day += daysPassed;
+		hour -= (daysPassed * 24);
+		triggerHourEvents();
+
 		// This event has to be triggered after the hour is checked the hour isn't 24 when the event is sent
-		events.trigger("hourUpdate");
 		events.trigger("dayUpdate");
 
 		// lose the game if the game reaches 30 days

--- a/source/core/src/test/com/csse3200/game/components/ship/ShipTimeSkipComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/ship/ShipTimeSkipComponentTest.java
@@ -1,0 +1,63 @@
+package com.csse3200.game.components.ship;
+
+import com.csse3200.game.entities.Entity;
+import com.csse3200.game.extensions.GameExtension;
+import com.csse3200.game.services.GameTime;
+import com.csse3200.game.services.ServiceLocator;
+import com.csse3200.game.services.TimeService;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(GameExtension.class)
+class ShipTimeSkipComponentTest {
+    @ParameterizedTest(name = "Updates the time from {0}d {1}h {2}m to {3}d 6h 0m when unlocked")
+    @MethodSource({"updatesTimeWhenUnlockedParams"})
+    void updatesTimeWhenUnlocked(int initialDay, int initialHour, int initialMinute, int expectedDay) {
+        ServiceLocator.registerTimeSource(new GameTime());
+
+        TimeService mockTimeService = spy(TimeService.class);
+        ServiceLocator.registerTimeService(mockTimeService);
+
+        mockTimeService.setDay(initialDay);
+        mockTimeService.setHour(initialHour);
+        mockTimeService.setMinute(initialMinute);
+
+        ShipTimeSkipComponent component = new ShipTimeSkipComponent();
+        Entity testEntity = new Entity().addComponent(component);
+        testEntity.create();
+
+        // not unlocked yet, shouldn't do anything
+        testEntity.getEvents().trigger("interact");
+        verify(mockTimeService, times(0)).setNearestTime(TimeService.MORNING_HOUR);
+
+        // unlock the feature
+        testEntity.getEvents().trigger("progressUpdated", 4, new HashSet<>(List.of(ShipProgressComponent.Feature.BED)));
+
+        // should trigger a time change now
+        testEntity.getEvents().trigger("interact");
+        verify(mockTimeService, times(1)).setNearestTime(TimeService.MORNING_HOUR);
+
+        assert mockTimeService.getDay() == expectedDay;
+        assert mockTimeService.getHour() == TimeService.MORNING_HOUR;
+        assert mockTimeService.getMinute() == 0;
+    }
+
+    private static Stream<Arguments> updatesTimeWhenUnlockedParams() {
+        return Stream.of(
+                // (initialDay, initialHour, initialMinute, expectedDay)
+                arguments(0, 5, 0, 0),
+                arguments(0, 5, 59, 0),
+                arguments(0, 6, 0, 0),
+                arguments(0, 6, 1, 1)
+        );
+    }
+}

--- a/source/core/src/test/com/csse3200/game/components/ship/ShipTimeSkipComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/ship/ShipTimeSkipComponentTest.java
@@ -52,14 +52,14 @@ class ShipTimeSkipComponentTest {
 
         // not unlocked yet, shouldn't do anything
         testEntity.getEvents().trigger("interact");
-        verify(mockTimeSource, times(0)).setTimeScale(100f);
+        verify(mockTimeSource, times(0)).setTimeScale(200f);
 
         // unlock the feature
         testEntity.getEvents().trigger("progressUpdated", 4, new HashSet<>(List.of(ShipProgressComponent.Feature.BED)));
 
         // should trigger a time change now
         testEntity.getEvents().trigger("interact");
-        verify(mockTimeSource, times(1)).setTimeScale(100f);
+        verify(mockTimeSource, times(1)).setTimeScale(200f);
 
         while (!isMorningHour) {
             timeService.update();

--- a/source/core/src/test/com/csse3200/game/components/ship/ShipTimeSkipComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/ship/ShipTimeSkipComponentTest.java
@@ -6,6 +6,7 @@ import com.csse3200.game.services.GameTime;
 import com.csse3200.game.services.ServiceLocator;
 import com.csse3200.game.services.TimeService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -77,5 +78,26 @@ class ShipTimeSkipComponentTest {
                 arguments(0, 6, 0, 1),
                 arguments(0, 6, 1, 1)
         );
+    }
+
+    @Test
+    void doesNotTriggerTimeScaleWhenTimeSkipNotInProgress() {
+        GameTime mockTimeSource = spy(GameTime.class);
+        ServiceLocator.registerTimeSource(mockTimeSource);
+
+        TimeService timeService = new TimeService();
+        ServiceLocator.registerTimeService(timeService);
+
+        timeService.getEvents().addListener("morningTime", this::setMorningHour);
+
+        ShipTimeSkipComponent component = new ShipTimeSkipComponent();
+        Entity testEntity = new Entity().addComponent(component);
+        testEntity.create();
+
+        while (!isMorningHour) {
+            timeService.update();
+        }
+
+        verify(mockTimeSource, times(0)).setTimeScale(1f);
     }
 }


### PR DESCRIPTION
* added `setNearestTime`  to the TimeService to allow setting the time to the next future value

- once the time skip is unlocked, interacting with the ship will skip to the next morning
    * this currently skips straight to the next morning since increasing the time scale is tied to the fps cap which doesn't really look that great
    * potential to add a cutscene in the future to make it more immersive instead
