### PR TITLE
#424 Adds individual events for both the cone light and aura light.

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/AuraLightComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/AuraLightComponent.java
@@ -76,6 +76,7 @@ public class AuraLightComponent extends Component{
 		super.create();
 		light.setPosition(entity.getCenterPosition());
 		entity.getEvents().addListener("toggleLight", this::toggleLight);
+		entity.getEvents().addListener("toggleAuraLight", this::toggleLight);
 	}
 
 	/**

--- a/source/core/src/main/com/csse3200/game/components/ConeLightComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/ConeLightComponent.java
@@ -111,6 +111,7 @@ public class ConeLightComponent extends Component {
 		super.create();
 		light.setPosition(entity.getCenterPosition());
 		entity.getEvents().addListener("toggleLight", this::toggleLight);
+		entity.getEvents().addListener("toggleConeLight", this::toggleLight);
 	}
 
 	/**


### PR DESCRIPTION
As mentioned in #421  and #424, light components should get their own events as well as `toggleLight`. 