### PR TITLE
#350 Implemented `ShipPartTileComponent`

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
@@ -383,18 +383,6 @@ public class SpaceGameArea extends GameArea {
 
       shipDebris.setPosition(terrain.tileToWorldPosition(randomPos));
     });
-
-    // FOR TESTINGGGGG (aka TODO: get rid of later)
-    TerrainTile tile = gameMap.getTile(new Vector2(40, 40));
-
-    Entity partTile = ShipPartTileFactory.createShipPartTile(new Vector2(40, 40));
-    ServiceLocator.getEntityService().register(partTile);
-    tile.setOccupant(partTile);
-    tile.setOccupied();
-
-    Entity shipDebris = ShipDebrisFactory.createShipDebris(player);
-
-    partTile.getComponent(ShipPartTileComponent.class).addShipDebris(shipDebris);
   }
 
   private Entity spawnPlayer() {

--- a/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
@@ -3,10 +3,7 @@ package com.csse3200.game.areas;
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.math.GridPoint2;
 import com.badlogic.gdx.math.Vector2;
-import com.csse3200.game.areas.terrain.CropTileComponent;
-import com.csse3200.game.areas.terrain.GameMap;
-import com.csse3200.game.areas.terrain.TerrainCropTileFactory;
-import com.csse3200.game.areas.terrain.TerrainFactory;
+import com.csse3200.game.areas.terrain.*;
 import com.csse3200.game.areas.weather.ClimateController;
 import com.csse3200.game.components.gamearea.GameAreaDisplay;
 import com.csse3200.game.components.items.ItemType;
@@ -372,14 +369,19 @@ public class SpaceGameArea extends GameArea {
 
     IntStream.range(0,15).forEach(i -> {
       GridPoint2 randomPos = RandomUtils.random(minPos, maxPos);
+      TerrainTile tile = gameMap.getTile(randomPos);
 
-      while (!gameMap.getTile(randomPos).isTraversable()) {
+      while (!tile.isTraversable() || tile.isOccupied()) {
         randomPos = RandomUtils.random(minPos, maxPos);
-
+        tile = gameMap.getTile(randomPos);
       }
 
       Entity shipDebris = ShipDebrisFactory.createShipDebris(player);
-      spawnEntityAt(shipDebris, randomPos, true, true);
+      ServiceLocator.getEntityService().register(shipDebris);
+      tile.setOccupant(shipDebris);
+      tile.setOccupied();
+
+      shipDebris.setPosition(terrain.tileToWorldPosition(randomPos));
     });
   }
 

--- a/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
@@ -383,6 +383,18 @@ public class SpaceGameArea extends GameArea {
 
       shipDebris.setPosition(terrain.tileToWorldPosition(randomPos));
     });
+
+    // FOR TESTINGGGGG (aka TODO: get rid of later)
+    TerrainTile tile = gameMap.getTile(new Vector2(40, 40));
+
+    Entity partTile = ShipPartTileFactory.createShipPartTile(new Vector2(40, 40));
+    ServiceLocator.getEntityService().register(partTile);
+    tile.setOccupant(partTile);
+    tile.setOccupied();
+
+    Entity shipDebris = ShipDebrisFactory.createShipDebris(player);
+
+    partTile.getComponent(ShipPartTileComponent.class).addShipDebris(shipDebris);
   }
 
   private Entity spawnPlayer() {

--- a/source/core/src/main/com/csse3200/game/areas/terrain/CropTileComponent.java
+++ b/source/core/src/main/com/csse3200/game/areas/terrain/CropTileComponent.java
@@ -136,11 +136,12 @@ public class CropTileComponent extends Component {
 	/**
 	 * Destroys both the tile and any plant that is on it
 	 */
-	private void destroyTile() {
+	private void destroyTile(TerrainTile tile) {
 		if (isOccupied()) {
 			plant.getEvents().trigger("destroyPlant");
 			this.setUnoccupied();
 		} else {
+			if (tile != null) tile.removeOccupant();
 			entity.dispose();
 		}
 	}
@@ -216,7 +217,7 @@ public class CropTileComponent extends Component {
 	 *
 	 * @return whether the tile is occupied by the plant
 	 */
-	public boolean isOccupied() {
+	private boolean isOccupied() {
 		return plant != null;
 	}
 

--- a/source/core/src/main/com/csse3200/game/areas/terrain/ShipPartTileComponent.java
+++ b/source/core/src/main/com/csse3200/game/areas/terrain/ShipPartTileComponent.java
@@ -1,0 +1,72 @@
+package com.csse3200.game.areas.terrain;
+
+import com.csse3200.game.components.Component;
+import com.csse3200.game.entities.Entity;
+import com.csse3200.game.entities.factories.ItemFactory;
+import com.csse3200.game.services.ServiceLocator;
+
+/**
+ * A tile that drops a ship part on destroy. Can contain a ship debris
+ * which must be destroyed first if it exists.
+ */
+public class ShipPartTileComponent extends Component {
+    private Entity shipDebris;
+
+    public ShipPartTileComponent() {
+        shipDebris = null;
+    }
+
+    @Override
+    public void create() {
+        entity.getEvents().addListener("destroy", this::destroyTile);
+    }
+
+    /**
+     * Set the ship debris associated with this tile.
+     * @param shipDebris
+     */
+    public void addShipDebris(Entity shipDebris) {
+        this.shipDebris = shipDebris;
+        this.shipDebris.setPosition(entity.getPosition());
+        ServiceLocator.getEntityService().register(this.shipDebris);
+    }
+
+    /**
+     * A ship debris is present in this tile.
+     * @return true if there is ship debris present
+     */
+    private boolean containsShipDebris() {
+        return shipDebris != null;
+    }
+
+    /**
+     * Trigger the ship debris' destroy event and remove it
+     * from the tile.
+     */
+    private void destroyShipDebris() {
+        shipDebris.getEvents().trigger("destroy", null);
+        shipDebris = null;
+    }
+
+    /**
+     * Destroys the tile. If a ship debris is present, destroy it first.
+     * Drops a ship part on final destroy.
+     *
+     * @param tile the terrain tile that will become unoccupied once the ship
+     *             tile is destroyed.
+     */
+    private void destroyTile(TerrainTile tile) {
+        if (containsShipDebris()) {
+            destroyShipDebris();
+        } else {
+            // drop a ship part
+            Entity item = ItemFactory.createEgg(); // the ship is made of eggs apparently
+            item.setPosition(entity.getPosition());
+            ServiceLocator.getEntityService().register(item);
+
+            // remove self from the terrain tile & self-destruct
+            tile.removeOccupant();
+            entity.dispose();
+        }
+    }
+}

--- a/source/core/src/main/com/csse3200/game/areas/terrain/ShipPartTileComponent.java
+++ b/source/core/src/main/com/csse3200/game/areas/terrain/ShipPartTileComponent.java
@@ -63,7 +63,7 @@ public class ShipPartTileComponent extends Component {
         } else {
             // drop a ship part
             Entity item = ItemFactory.createEgg(); // the ship is made of eggs apparently
-            item.setPosition(entity.getPosition());
+            item.setCenterPosition(entity.getCenterPosition());
             ServiceLocator.getEntityService().register(item);
 
             // remove self from the terrain tile & self-destruct

--- a/source/core/src/main/com/csse3200/game/areas/terrain/ShipPartTileComponent.java
+++ b/source/core/src/main/com/csse3200/game/areas/terrain/ShipPartTileComponent.java
@@ -23,7 +23,8 @@ public class ShipPartTileComponent extends Component {
 
     /**
      * Set the ship debris associated with this tile.
-     * @param shipDebris
+     *
+     * @param shipDebris entity to be added
      */
     public void addShipDebris(Entity shipDebris) {
         this.shipDebris = shipDebris;
@@ -33,6 +34,7 @@ public class ShipPartTileComponent extends Component {
 
     /**
      * A ship debris is present in this tile.
+     *
      * @return true if there is ship debris present
      */
     private boolean containsShipDebris() {
@@ -65,7 +67,7 @@ public class ShipPartTileComponent extends Component {
             ServiceLocator.getEntityService().register(item);
 
             // remove self from the terrain tile & self-destruct
-            tile.removeOccupant();
+            if (tile != null) tile.removeOccupant();
             entity.dispose();
         }
     }

--- a/source/core/src/main/com/csse3200/game/areas/terrain/ShipPartTileFactory.java
+++ b/source/core/src/main/com/csse3200/game/areas/terrain/ShipPartTileFactory.java
@@ -1,0 +1,32 @@
+package com.csse3200.game.areas.terrain;
+
+import com.badlogic.gdx.math.Vector2;
+import com.csse3200.game.entities.Entity;
+import com.csse3200.game.entities.EntityType;
+import com.csse3200.game.physics.components.ColliderComponent;
+import com.csse3200.game.physics.components.PhysicsComponent;
+import com.csse3200.game.rendering.DynamicTextureRenderComponent;
+
+public class ShipPartTileFactory {
+
+    /**
+     * Creates an Entity that contains a ShipPartTileComponent.
+     *
+     * @param position where the entity will be placed.
+     * @return Entity shipPartTile
+     */
+    public static Entity createShipPartTile(Vector2 position) {
+        // TODO: change texture later
+        DynamicTextureRenderComponent renderComponent = new DynamicTextureRenderComponent("images/cropTile.png");
+        renderComponent.setLayer(1);
+
+        Entity shipPartTile = new Entity(EntityType.Tile)
+                .addComponent(new ColliderComponent().setSensor(true))
+                .addComponent(new PhysicsComponent())
+                .addComponent(new ShipPartTileComponent())
+                .addComponent(renderComponent);
+
+        shipPartTile.setPosition(position);
+        return shipPartTile;
+    }
+}

--- a/source/core/src/main/com/csse3200/game/components/items/ItemActions.java
+++ b/source/core/src/main/com/csse3200/game/components/items/ItemActions.java
@@ -218,8 +218,7 @@ public class ItemActions extends Component {
                       .contains(tile.getOccupant().getType())
       ) {
         // TODO this good
-        tile.getOccupant().getEvents().trigger("destroy");
-        tile.removeOccupant();
+        tile.getOccupant().getEvents().trigger("destroy", tile);
         return true;
         // TODO Above this is amazing
       } else {

--- a/source/core/src/main/com/csse3200/game/components/items/ItemActions.java
+++ b/source/core/src/main/com/csse3200/game/components/items/ItemActions.java
@@ -1,13 +1,6 @@
 package com.csse3200.game.components.items;
 
-import static com.csse3200.game.areas.terrain.TerrainCropTileFactory.createTerrainEntity;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Function;
-
 import com.badlogic.gdx.math.Vector2;
-import com.csse3200.game.areas.GameArea;
 import com.csse3200.game.areas.terrain.CropTileComponent;
 import com.csse3200.game.areas.terrain.GameMap;
 import com.csse3200.game.areas.terrain.TerrainCropTileFactory;
@@ -18,9 +11,12 @@ import com.csse3200.game.components.npc.TamableComponent;
 import com.csse3200.game.components.player.InventoryComponent;
 import com.csse3200.game.entities.Entity;
 import com.csse3200.game.entities.EntityType;
-import com.csse3200.game.entities.factories.PlantFactory;
 import com.csse3200.game.services.FactoryService;
 import com.csse3200.game.services.ServiceLocator;
+
+import java.util.List;
+
+import static com.csse3200.game.areas.terrain.TerrainCropTileFactory.createTerrainEntity;
 
 public class ItemActions extends Component {
 
@@ -64,10 +60,7 @@ public class ItemActions extends Component {
       }
       case SHOVEL -> {
         resultStatus = shovel(tile);
-        if (!resultStatus) {
-          return destroy(player, mouseWorldPos);
-        }
-        return true;
+        return resultStatus;
       }
       case SCYTHE -> {
         resultStatus = harvest(tile);
@@ -220,7 +213,10 @@ public class ItemActions extends Component {
       }
       // TODO Below here is temp code all that should be called here is whatever is surronding by the other two todos
       // Just dont have time and want it out
-      if (tile.getOccupant().getType() == EntityType.Tile) {
+      if (
+              List.of(EntityType.Tile, EntityType.ShipDebris)
+                      .contains(tile.getOccupant().getType())
+      ) {
         // TODO this good
         tile.getOccupant().getEvents().trigger("destroy");
         tile.removeOccupant();
@@ -325,33 +321,6 @@ public class ItemActions extends Component {
     }
 
     entityToFeed.getEvents().trigger("feed");
-    return true;
-  }
-
-  /**
-   * Triggers a destroy event on the destroyable entity.
-   *
-   * @param player player entity
-   * @param mouseWorldPos position to check for destroyable entity
-   * @return true if destroyed, false otherwise
-   */
-  private boolean destroy(Entity player, Vector2 mouseWorldPos) {
-    InteractionDetector interactionDetector = player.getComponent(InteractionDetector.class);
-
-    if (interactionDetector == null) {
-      return false;
-    }
-
-    List<Entity> entities = interactionDetector.getEntitiesTowardsPosition(mouseWorldPos);
-    entities.removeIf(entity -> entity.getType() != EntityType.ShipDebris);
-
-    Entity entityToDestroy = interactionDetector.getNearest(entities);
-
-    if (entityToDestroy == null) {
-      return false;
-    }
-
-    entityToDestroy.getEvents().trigger("destroy");
     return true;
   }
 }

--- a/source/core/src/main/com/csse3200/game/components/ship/ShipDebrisComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/ship/ShipDebrisComponent.java
@@ -1,5 +1,6 @@
 package com.csse3200.game.components.ship;
 
+import com.csse3200.game.areas.terrain.TerrainTile;
 import com.csse3200.game.components.Component;
 import com.csse3200.game.missions.MissionManager;
 import com.csse3200.game.services.ServiceLocator;
@@ -23,8 +24,9 @@ public class ShipDebrisComponent extends Component {
     /**
      * Trigger the mission manager's DEBRIS_CLEARED event then self destruct.
      */
-    void destroy() {
+    void destroy(TerrainTile tile) {
         missionManager.getEvents().trigger(MissionManager.MissionEvent.DEBRIS_CLEARED.name());
+        if (tile != null) tile.removeOccupant();
         entity.dispose();
     }
 }

--- a/source/core/src/test/com/csse3200/game/areas/terrain/CropTileComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/areas/terrain/CropTileComponentTest.java
@@ -226,11 +226,11 @@ public class CropTileComponentTest {
         Function<CropTileComponent, Entity> plantFactoryMethod = cropTileComponent -> plant;
         cropTile1.getEvents().trigger("plant", plantFactoryMethod);
         verify(mockEntityService).register(plant);
-        cropTile1.getEvents().trigger("destroy");
+        cropTile1.getEvents().trigger("destroy", null);
         verify(mockEntityService, never()).unregister(cropTile1);
-        cropTile1.getEvents().trigger("destroy");
+        cropTile1.getEvents().trigger("destroy", null);
         verify(mockEntityService).unregister(cropTile1);
-        cropTile2.getEvents().trigger("destroy");
+        cropTile2.getEvents().trigger("destroy", null);
         verify(mockEntityService).unregister(cropTile2);
     }
 }

--- a/source/core/src/test/com/csse3200/game/areas/terrain/ShipPartTileComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/areas/terrain/ShipPartTileComponentTest.java
@@ -1,0 +1,75 @@
+package com.csse3200.game.areas.terrain;
+
+import com.csse3200.game.components.ship.ShipDebrisComponent;
+import com.csse3200.game.entities.Entity;
+import com.csse3200.game.entities.EntityService;
+import com.csse3200.game.entities.EntityType;
+import com.csse3200.game.entities.factories.ItemFactory;
+import com.csse3200.game.extensions.GameExtension;
+import com.csse3200.game.missions.MissionManager;
+import com.csse3200.game.services.ServiceLocator;
+import com.csse3200.game.services.TimeService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(GameExtension.class)
+public class ShipPartTileComponentTest {
+    @Test
+    void destroysShipDebrisFirst() {
+        ServiceLocator.registerTimeService(new TimeService());
+        ServiceLocator.registerMissionManager(new MissionManager());
+
+        EntityService mockEntityService = spy(EntityService.class);
+        ServiceLocator.registerEntityService(mockEntityService);
+
+        Entity shipPartTile = new Entity(EntityType.Tile)
+                .addComponent(new ShipPartTileComponent());
+        mockEntityService.register(shipPartTile);
+
+        Entity shipDebris = new Entity(EntityType.ShipDebris)
+                .addComponent(new ShipDebrisComponent());
+
+        // should register the shipDebris when added to the shipPartTile
+        shipPartTile.getComponent(ShipPartTileComponent.class).addShipDebris(shipDebris);
+        verify(mockEntityService, times(1)).register(shipDebris);
+
+        // should only destroy the shipDebris
+        shipPartTile.getEvents().trigger("destroy", null);
+        verify(mockEntityService, times(1)).unregister(shipDebris);
+        verify(mockEntityService, times(0)).unregister(shipPartTile);
+    }
+
+    @Test
+    void dropsItemOnDestroyAndRemovesSelfFromTerrainTile() {
+        EntityService mockEntityService = spy(EntityService.class);
+        ServiceLocator.registerEntityService(mockEntityService);
+
+        TerrainTile terrainTile = new TerrainTile(null, TerrainTile.TerrainCategory.GRASS);
+        TerrainTile mockTerrainTile = spy(terrainTile);
+
+        Entity shipPartTile = new Entity(EntityType.Tile)
+                .addComponent(new ShipPartTileComponent());
+        mockEntityService.register(shipPartTile);
+
+        mockTerrainTile.setOccupant(shipPartTile);
+        mockTerrainTile.setOccupied();
+
+        Entity mockItem = new Entity(EntityType.Item);
+
+        try (MockedStatic<ItemFactory> itemFactory = mockStatic(ItemFactory.class)) {
+            itemFactory.when(ItemFactory::createEgg).thenReturn(mockItem);
+
+            shipPartTile.getEvents().trigger("destroy", mockTerrainTile);
+
+            // shipPartTile should register the dropped item, then unregister self
+            verify(mockEntityService, times(1)).register(mockItem);
+            verify(mockEntityService, times(1)).unregister(shipPartTile);
+
+            // should also remove self from the terrain tile
+            verify(mockTerrainTile, times(1)).removeOccupant();
+        }
+    }
+}


### PR DESCRIPTION
* Added a Ship Part Tile that can hold a Ship Debris
* Ship Debris must be destroyed first before the Ship Part Tile can be destroyed
* Added a terrain tile to "destroy" events - fixes #419 


- the tile currently drops an egg, this will get updated once the Ship Part Item is implemented