### PR TITLE
Fix item consumable checking

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/terrain/CropTileComponent.java
+++ b/source/core/src/main/com/csse3200/game/areas/terrain/CropTileComponent.java
@@ -135,6 +135,14 @@ public class CropTileComponent extends Component {
 	}
 
 	/**
+	 * Returns whether the tile is fertilised.
+	 * @return True if the tile is fertilised, false otherwise.
+	 */
+	public boolean isFertilised() {
+		return isFertilised;
+	}
+
+	/**
 	 * Destroys both the tile and any plant that is on it
 	 */
 	private void destroyTile(TerrainTile tile) {
@@ -146,7 +154,6 @@ public class CropTileComponent extends Component {
 			entity.dispose();
 		}
 	}
-
 
 	/**
 	 * Plants a plant entity on the tile and stores the plant as a member variable in the tile

--- a/source/core/src/main/com/csse3200/game/components/items/ItemActions.java
+++ b/source/core/src/main/com/csse3200/game/components/items/ItemActions.java
@@ -312,8 +312,8 @@ public class ItemActions extends Component {
       if (cropTileComponent != null && !cropTileComponent.isFertilised()) {
         // Fertilising a crop tile should remove the item from the player inventory
         ServiceLocator.getGameArea().getPlayer().getComponent(InventoryComponent.class).removeItem(entity);
+        tile.getOccupant().getEvents().trigger("fertilise");
       }
-      tile.getOccupant().getEvents().trigger("fertilise");
       return true;
     }
     return false;
@@ -331,9 +331,9 @@ public class ItemActions extends Component {
       if (cropTileComponent != null && cropTileComponent.getPlant() == null) {
         // Planting using seeds should remove the item from player inventory
         ServiceLocator.getGameArea().getPlayer().getComponent(InventoryComponent.class).removeItem(entity);
+        tile.getOccupant().getEvents().trigger("plant", FactoryService.getPlantFactories()
+                .get(entity.getComponent(ItemComponent.class).getItemName().replace(" Seeds", "")));
       }
-      tile.getOccupant().getEvents().trigger("plant", FactoryService.getPlantFactories()
-              .get(entity.getComponent(ItemComponent.class).getItemName().replace(" Seeds", "")));
       return true;
     }
     return false;

--- a/source/core/src/main/com/csse3200/game/components/items/ItemActions.java
+++ b/source/core/src/main/com/csse3200/game/components/items/ItemActions.java
@@ -308,9 +308,12 @@ public class ItemActions extends Component {
    */
   private boolean fertilise(TerrainTile tile) {
     if (isCropTile(tile.getOccupant())) {
+      CropTileComponent cropTileComponent = tile.getOccupant().getComponent(CropTileComponent.class);
+      if (cropTileComponent != null && !cropTileComponent.isFertilised()) {
+        // Fertilising a crop tile should remove the item from the player inventory
+        ServiceLocator.getGameArea().getPlayer().getComponent(InventoryComponent.class).removeItem(entity);
+      }
       tile.getOccupant().getEvents().trigger("fertilise");
-      // Fertilising a crop tile should remove the item from the player inventory
-      ServiceLocator.getGameArea().getPlayer().getComponent(InventoryComponent.class).removeItem(entity);
       return true;
     }
     return false;
@@ -324,10 +327,13 @@ public class ItemActions extends Component {
    */
   private boolean plant(TerrainTile tile) {
     if (isCropTile(tile.getOccupant())) {
+      CropTileComponent cropTileComponent = tile.getOccupant().getComponent(CropTileComponent.class);
+      if (cropTileComponent != null && cropTileComponent.getPlant() == null) {
+        // Planting using seeds should remove the item from player inventory
+        ServiceLocator.getGameArea().getPlayer().getComponent(InventoryComponent.class).removeItem(entity);
+      }
       tile.getOccupant().getEvents().trigger("plant", FactoryService.getPlantFactories()
               .get(entity.getComponent(ItemComponent.class).getItemName().replace(" Seeds", "")));
-      // Planting using seeds should remove the item from player inventory
-      ServiceLocator.getGameArea().getPlayer().getComponent(InventoryComponent.class).removeItem(entity);
       return true;
     }
     return false;

--- a/source/core/src/main/com/csse3200/game/components/items/ItemActions.java
+++ b/source/core/src/main/com/csse3200/game/components/items/ItemActions.java
@@ -309,7 +309,7 @@ public class ItemActions extends Component {
   private boolean fertilise(TerrainTile tile) {
     if (isCropTile(tile.getOccupant())) {
       CropTileComponent cropTileComponent = tile.getOccupant().getComponent(CropTileComponent.class);
-      if (cropTileComponent != null && !cropTileComponent.isFertilised()) {
+      if (!cropTileComponent.isFertilised()) {
         // Fertilising a crop tile should remove the item from the player inventory
         ServiceLocator.getGameArea().getPlayer().getComponent(InventoryComponent.class).removeItem(entity);
         tile.getOccupant().getEvents().trigger("fertilise");
@@ -328,7 +328,7 @@ public class ItemActions extends Component {
   private boolean plant(TerrainTile tile) {
     if (isCropTile(tile.getOccupant())) {
       CropTileComponent cropTileComponent = tile.getOccupant().getComponent(CropTileComponent.class);
-      if (cropTileComponent != null && cropTileComponent.getPlant() == null) {
+      if (cropTileComponent.getPlant() == null) {
         // Planting using seeds should remove the item from player inventory
         ServiceLocator.getGameArea().getPlayer().getComponent(InventoryComponent.class).removeItem(entity);
         tile.getOccupant().getEvents().trigger("plant", FactoryService.getPlantFactories()


### PR DESCRIPTION
Fixes #523, although the current solution does not integrate with the `perishable` boolean logic.
(This could be updated in sprint 4 so the two implementations work together).