### PR TITLE
491 removeitem for held items

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/player/InventoryComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/player/InventoryComponent.java
@@ -438,6 +438,10 @@ public class InventoryComponent extends Component {
                 for (int i = 0; i < this.itemPlace.size(); i++) {
                     if (this.itemPlace.get(i).equals(item.getComponent(ItemComponent.class).getItemName())) {
                         this.itemPlace.remove(i);
+                        if(this.heldIndex == i) {
+                            this.heldItem = null;
+                            this.heldIndex = -1;
+                        }
                         setHeldItem(heldIndex);
                         break;
                     }


### PR DESCRIPTION
Bug fixed.
If the held Item count drops to 0, the held Item is set to null just it is as at start of game.