### PR TITLE
Use `ResourceService` for assets

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
@@ -245,7 +245,12 @@ public class SpaceGameArea extends GameArea {
           "images/ship/ship_debris.png",
           "images/ship/ship.png",
           "images/ship/ship_part.png",
-          "images/ship/ship_clue.png"
+          "images/ship/ship_clue.png",
+
+          "images/selected.png",
+          "images/itemFrame.png"
+
+
   };
 
   private static final String[] forestTextureAtlases = {

--- a/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
@@ -248,7 +248,9 @@ public class SpaceGameArea extends GameArea {
           "images/ship/ship_clue.png",
 
           "images/selected.png",
-          "images/itemFrame.png"
+          "images/itemFrame.png",
+          "images/PauseMenu/Pause_Overlay.jpg",
+          "images/PauseMenu/Pausenew.jpg"
 
 
   };

--- a/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/SpaceGameArea.java
@@ -1,7 +1,9 @@
 package com.csse3200.game.areas;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.GridPoint2;
 import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.csse3200.game.areas.terrain.*;
 import com.csse3200.game.areas.weather.ClimateController;
 import com.csse3200.game.components.gamearea.GameAreaDisplay;
@@ -39,7 +41,7 @@ public class SpaceGameArea extends GameArea {
   private static final float WALL_WIDTH = 0.1f;
   private EntitiesSpawner hostileSpawner;
 
-  private static final String[] forestTextures = {
+  private static final String[] texturePaths = {
           "images/tree.png",
           "images/ghost_king.png",
           "images/ghost_1.png",
@@ -255,7 +257,7 @@ public class SpaceGameArea extends GameArea {
 
   };
 
-  private static final String[] forestTextureAtlases = {
+  private static final String[] textureAtlasPaths = {
       "images/terrain_iso_grass.atlas", "images/ghost.atlas", "images/player.atlas", "images/ghostKing.atlas",
       "images/animals/chicken.atlas", "images/animals/cow.atlas", "images/tractor.atlas",
       "images/animals/astrolotl.atlas", "images/animals/oxygen_eater.atlas", "images/questgiver.atlas",
@@ -265,7 +267,7 @@ public class SpaceGameArea extends GameArea {
           "images/animals/bat.atlas", "images/projectiles/oxygen_eater_projectile.atlas",
           "images/ship/ship.atlas", "images/light.atlas", "images/projectiles/dragon_fly_projectile.atlas"
   };
-  private static final String[] forestSounds = {
+  private static final String[] soundPaths = {
           "sounds/Impact4.ogg", "sounds/car-horn-6408.mp3",
           "sounds/plants/aloeVera/click.wav", "sounds/plants/aloeVera/clickLore.wav",
           "sounds/plants/aloeVera/decay.wav", "sounds/plants/aloeVera/decayLore.wav",
@@ -293,6 +295,11 @@ public class SpaceGameArea extends GameArea {
           "sounds/plants/waterWeed/nearby.wav", "sounds/plants/waterWeed/nearbyLore.wav",
   };
 
+  String[] skinPaths = {
+          "flat-earth/skin/flat-earth-ui.json",
+          "gardens-of-the-galaxy/gardens-of-the-galaxy.json",
+          "gardens-of-the-galaxy-v2-orange/gardens-of-the-galaxy-v2-orange.json"
+  };
   private final GameMap gameMap;
 
   private Entity player;
@@ -529,9 +536,10 @@ public class SpaceGameArea extends GameArea {
   private void loadAssets() {
     logger.debug("Loading assets");
     ResourceService resourceService = ServiceLocator.getResourceService();
-    resourceService.loadTextures(forestTextures);
+    resourceService.loadTextures(texturePaths);
     resourceService.loadTextures(TerrainFactory.getMapTextures());
-    resourceService.loadTextureAtlases(forestTextureAtlases);
+    resourceService.loadTextureAtlases(textureAtlasPaths);
+    resourceService.loadSkins(skinPaths);
     try {
       ServiceLocator.getSoundService().getBackgroundMusicService()
               .loadSounds(Arrays.asList(BackgroundSoundFile.values()));
@@ -557,9 +565,9 @@ public class SpaceGameArea extends GameArea {
   private void unloadAssets() {
     logger.debug("Unloading assets");
     ResourceService resourceService = ServiceLocator.getResourceService();
-    resourceService.unloadAssets(forestTextures);
-    resourceService.unloadAssets(forestTextureAtlases);
-    resourceService.unloadAssets(forestSounds);
+    resourceService.unloadAssets(texturePaths);
+    resourceService.unloadAssets(textureAtlasPaths);
+    resourceService.unloadAssets(soundPaths);
   }
 
   @Override

--- a/source/core/src/main/com/csse3200/game/components/gamearea/GameAreaDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/gamearea/GameAreaDisplay.java
@@ -37,7 +37,7 @@ public class GameAreaDisplay extends UIComponent {
     super.create();
     ServiceLocator.registerCraftArea(this);
     addActors();
-    backgroundOverlay = new Image(new Texture(Gdx.files.internal("images/PauseMenu/Pause_Overlay.jpg")));
+    backgroundOverlay = new Image(ServiceLocator.getResourceService().getAsset("images/PauseMenu/Pause_Overlay.jpg", Texture.class));
     backgroundOverlay.setSize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
     backgroundOverlay.setColor(0, 0, 0, 0.8f);
     backgroundOverlay.setVisible(false);
@@ -67,7 +67,7 @@ public class GameAreaDisplay extends UIComponent {
     backgroundOverlay.setVisible(true); // Initially, set it to invisible
 
 
-    Image pauseMenu = new Image(new Texture(Gdx.files.internal("images/PauseMenu/Pausenew.jpg")));
+    Image pauseMenu = new Image(ServiceLocator.getResourceService().getAsset("images/PauseMenu/Pausenew.jpg", Texture.class));
     pauseMenu.setSize(1300, 700);
     pauseMenu.setPosition((float) (Gdx.graphics.getWidth() / 2.0 - pauseMenu.getWidth() / 2),
             (float) (Gdx.graphics.getHeight() / 2.0 - pauseMenu.getHeight() / 2));

--- a/source/core/src/main/com/csse3200/game/components/inventory/InventoryDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/inventory/InventoryDisplay.java
@@ -3,6 +3,7 @@ package com.csse3200.game.components.inventory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+
 import com.csse3200.game.services.ServiceLocator;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
 import org.jetbrains.annotations.NotNull;
@@ -20,253 +21,257 @@ import com.badlogic.gdx.graphics.Texture;
  * An ui component for displaying player stats, e.g. health.
  */
 public class InventoryDisplay extends UIComponent {
-    private InventoryComponent inventory;
-    private final Skin skin = new Skin(Gdx.files.internal("gardens-of-the-galaxy/gardens-of-the-galaxy.json"));
-    private final Table table = new Table(skin);
-    private Window window;
-    private final ArrayList<ItemSlot> slots = new ArrayList<>();
-    private boolean isOpen = false;
-    private DragAndDrop dnd;
-    private ArrayList<Actor> actors;
-    private Map<Stack,ItemSlot> map;
-    private Map<ItemSlot,Integer> indexes;
-    private final Integer size;
-    private final Integer rowSize;
-    private final boolean toolbar;
-    private final String refreshEvent;
-    private final String openEvent;
-    private final InventoryDisplayManager inventoryDisplayManager;
+	private InventoryComponent inventory;
+	private final Skin skin = ServiceLocator.getResourceService().getAsset("gardens-of-the-galaxy/gardens-of-the-galaxy.json", Skin.class);
+	private final Table table = new Table(skin);
+	private Window window;
+	private final ArrayList<ItemSlot> slots = new ArrayList<>();
+	private boolean isOpen = false;
+	private DragAndDrop dnd;
+	private ArrayList<Actor> actors;
+	private Map<Stack, ItemSlot> map;
+	private Map<ItemSlot, Integer> indexes;
+	private final Integer size;
+	private final Integer rowSize;
+	private final boolean toolbar;
+	private final String refreshEvent;
+	private final String openEvent;
+	private final InventoryDisplayManager inventoryDisplayManager;
 
-    /**
-     * Constructor for class
-     * @param size size of inventory
-     * @param rowSize amount of items per row
-     */
-    public InventoryDisplay(String refreshEvent, String openEvent, Integer size, Integer rowSize, Boolean toolbar) {
-        this.size = size;
-        this.rowSize = rowSize;
-        this.toolbar = toolbar;
-        this.refreshEvent = refreshEvent;
-        this.openEvent = openEvent;
-        inventoryDisplayManager = ServiceLocator.getInventoryDisplayManager();
-    }
+	/**
+	 * Constructor for class
+	 *
+	 * @param size    size of inventory
+	 * @param rowSize amount of items per row
+	 */
+	public InventoryDisplay(String refreshEvent, String openEvent, Integer size, Integer rowSize, Boolean toolbar) {
+		this.size = size;
+		this.rowSize = rowSize;
+		this.toolbar = toolbar;
+		this.refreshEvent = refreshEvent;
+		this.openEvent = openEvent;
+		inventoryDisplayManager = ServiceLocator.getInventoryDisplayManager();
+	}
 
-    /**
-     * Creates reusable ui styles and adds actors to the stage.
-     */
-    @Override
-    public void create() {
-        super.create();
-        initialiseInventory();
-        entity.getEvents().addListener(openEvent,this::toggleOpen);
-        entity.getEvents().addListener(refreshEvent,this::refreshInventory);
-        inventoryDisplayManager.addInventoryDisplay(this);
-    }
+	/**
+	 * Creates reusable ui styles and adds actors to the stage.
+	 */
+	@Override
+	public void create() {
+		super.create();
+		initialiseInventory();
+		entity.getEvents().addListener(openEvent, this::toggleOpen);
+		entity.getEvents().addListener(refreshEvent, this::refreshInventory);
+		inventoryDisplayManager.addInventoryDisplay(this);
+	}
 
-    /**
-     * Initialises the inventoryDisplay and adds it to the stage.
-     * @see Table for positioning options
-     */
-    private void initialiseInventory() {
-        window = new Window(entity.getType() + " Inventory", skin);
+	/**
+	 * Initialises the inventoryDisplay and adds it to the stage.
+	 *
+	 * @see Table for positioning options
+	 */
+	private void initialiseInventory() {
+		window = new Window(entity.getType() + " Inventory", skin);
 
-        // create variables needed for drag and drop
-        dnd = new DragAndDrop();
-        actors = new ArrayList<>();
-        map = new HashMap<>();
-        indexes  = new HashMap<>();
+		// create variables needed for drag and drop
+		dnd = new DragAndDrop();
+		actors = new ArrayList<>();
+		map = new HashMap<>();
+		indexes = new HashMap<>();
 
-        table.defaults().size(64, 64);
-        table.pad(10);
+		table.defaults().size(64, 64);
+		table.pad(10);
 
-    // loop through entire table and create itemSlots and add the slots to the stored array
-    for (int i = 0; i < size; i++) {
-      ItemSlot slot;
-      if (inventory != null && this.inventory.getItem(i) != null) {
-        slot = new ItemSlot(this.inventory.getItem(i).getComponent(ItemComponent.class).getItemTexture(), false);
-        actors.add(slot.getDraggable());
-      } else {
-        slot = new ItemSlot(false);
-      }
+		// loop through entire table and create itemSlots and add the slots to the stored array
+		for (int i = 0; i < size; i++) {
+			ItemSlot slot;
+			if (inventory != null && this.inventory.getItem(i) != null) {
+				slot = new ItemSlot(this.inventory.getItem(i).getComponent(ItemComponent.class).getItemTexture(), false);
+				actors.add(slot.getDraggable());
+			} else {
+				slot = new ItemSlot(false);
+			}
 
-            table.add(slot).width(70).height(70).pad(10, 10, 10, 10);
+			table.add(slot).width(70).height(70).pad(10, 10, 10, 10);
 
-      if ((i + 1) % rowSize == 0) {
-        table.row();
-      }
-      slots.add(slot);
-      map.put(slot.getDraggable(), slot);
-      indexes.put(slot, i);
-      if (slot.getItemImage() != null) {
-        slot.getItemImage().setDebug(false);
-      }
-    }
+			if ((i + 1) % rowSize == 0) {
+				table.row();
+			}
+			slots.add(slot);
+			map.put(slot.getDraggable(), slot);
+			indexes.put(slot, i);
+			if (slot.getItemImage() != null) {
+				slot.getItemImage().setDebug(false);
+			}
+		}
 
-        // Create a window for the inventory using the skin
-        window.pad(40, 20, 20, 20);
-        window.add(table);
-        window.pack();
-        window.setMovable(false);
-        window.setVisible(false);
-        stage.addActor(window);
-        setDragItems(actors, map);
-    }
+		// Create a window for the inventory using the skin
+		window.pad(40, 20, 20, 20);
+		window.add(table);
+		window.pack();
+		window.setMovable(false);
+		window.setVisible(false);
+		stage.addActor(window);
+		setDragItems(actors, map);
+	}
 
-    /**
-     * Update Inventory user interface
-     */
+	/**
+	 * Update Inventory user interface
+	 */
 
-    private void updateInventory() {
-        dnd.clear();
-        actors.clear(); // Clear the actors ArrayList
+	private void updateInventory() {
+		dnd.clear();
+		actors.clear(); // Clear the actors ArrayList
 
-        for (int i = 0; i < size; i++) {
-            ItemComponent item;
-            Texture itemTexture;
-            int itemCount;
+		for (int i = 0; i < size; i++) {
+			ItemComponent item;
+			Texture itemTexture;
+			int itemCount;
 
-            // if the item isn't null we will update the position, this will be in future replaced by an event
-            if (inventory != null && inventory.getItem(i) != null) {
-                item = inventory.getItem(i).getComponent(ItemComponent.class);
-                itemCount = inventory.getItemCount(item.getEntity());
-                itemTexture = item.getItemTexture();
-                ItemSlot curSlot = slots.get(i);
-                curSlot.setItemImage(new Image(itemTexture));
-                actors.add(curSlot.getDraggable());
-                curSlot.setCount(itemCount);
-                map.put(curSlot.getDraggable(), curSlot);
+			// if the item isn't null we will update the position, this will be in future replaced by an event
+			if (inventory != null && inventory.getItem(i) != null) {
+				item = inventory.getItem(i).getComponent(ItemComponent.class);
+				itemCount = inventory.getItemCount(item.getEntity());
+				itemTexture = item.getItemTexture();
+				ItemSlot curSlot = slots.get(i);
+				curSlot.setItemImage(new Image(itemTexture));
+				actors.add(curSlot.getDraggable());
+				curSlot.setCount(itemCount);
+				map.put(curSlot.getDraggable(), curSlot);
 
 
+				slots.set(i, curSlot);
+			} else {
+				ItemSlot curSlot = slots.get(i);
+				curSlot.setItemImage(null);
+				curSlot.getDraggable().clear();
 
-        slots.set(i, curSlot);
-      }
-      else {
-        ItemSlot curSlot = slots.get(i);
-        curSlot.setItemImage(null);
-        curSlot.getDraggable().clear();
+				slots.set(i, curSlot);
+			}
 
-        slots.set(i, curSlot);
-      }
+		}
+		dnd = new DragAndDrop();
+		setDragItems(actors, map);
+	}
 
-    }
-    dnd = new DragAndDrop();
-    setDragItems(actors, map);
-  }
+	/**
+	 * Set Drag Items
+	 *
+	 * @param actors list of actors
+	 * @param map    images and their respective item slot
+	 */
+	public void setDragItems(@NotNull ArrayList<Actor> actors, Map<Stack, ItemSlot> map) {
+		for (Actor item : actors) {
+			dnd.addSource(new DragAndDrop.Source(item) {
+				final DragAndDrop.Payload payload = new DragAndDrop.Payload();
 
-  /**
-   * Set Drag Items
-   * @param actors list of actors
-   * @param map images and their respective item slot
-   */
-  public void setDragItems(@NotNull ArrayList<Actor> actors, Map<Stack,ItemSlot> map) {
-      for (Actor item : actors) {
-          dnd.addSource(new DragAndDrop.Source(item) {
-              final DragAndDrop.Payload payload = new DragAndDrop.Payload();
+				@Override
+				public DragAndDrop.Payload dragStart(InputEvent event, float x, float y, int pointer) {
+					payload.setObject(getActor());
+					payload.setDragActor(getActor());
+					stage.addActor(getActor());
+					dnd.setDragActorPosition(50, -getActor().getHeight() / 2);
 
-              @Override
-              public DragAndDrop.Payload dragStart(InputEvent event, float x, float y, int pointer) {
-                  payload.setObject(getActor());
-                  payload.setDragActor(getActor());
-                  stage.addActor(getActor());
-                  dnd.setDragActorPosition(50, -getActor().getHeight() / 2);
+					return payload;
+				}
 
-                  return payload;
-              }
+				@Override
+				public void dragStop(InputEvent event, float x, float y, int pointer, DragAndDrop.Payload payload, DragAndDrop.Target target) {
+					if (target == null) {
+						ItemSlot itemSlot = map.get(getActor());
+						itemSlot.removeActor(getActor());
+						itemSlot.add(getActor());
+					}
+				}
+			});
+		}
 
-              @Override
-              public void dragStop(InputEvent event, float x, float y, int pointer, DragAndDrop.Payload payload, DragAndDrop.Target target) {
-                  if (target == null) {
-                      ItemSlot itemSlot = map.get(getActor());
-                      itemSlot.removeActor(getActor());
-                      itemSlot.add(getActor());
-                  }
-              }
-          });
-      }
+		for (Cell<?> targetItem : table.getCells()) {
+			dnd.addTarget(new DragAndDrop.Target(targetItem.getActor()) {
+				final ItemSlot slot = (ItemSlot) targetItem.getActor();
 
-      for (Cell<?> targetItem : table.getCells()) {
-          dnd.addTarget(new DragAndDrop.Target(targetItem.getActor()) {
-              final ItemSlot slot = (ItemSlot) targetItem.getActor();
+				@Override
+				public boolean drag(DragAndDrop.Source source, DragAndDrop.Payload payload, float x, float y, int pointer) {
+					return true;
+				}
 
-              @Override
-              public boolean drag(DragAndDrop.Source source, DragAndDrop.Payload payload, float x, float y, int pointer) {
-                  return true;
-              }
+				@Override
+				public void drop(DragAndDrop.Source source, DragAndDrop.Payload payload, float x, float y, int pointer) {
+					ItemSlot sourceSlot = map.get((source.getActor()));
 
-              @Override
-              public void drop(DragAndDrop.Source source, DragAndDrop.Payload payload, float x, float y, int pointer) {
-                  ItemSlot sourceSlot = map.get((source.getActor()));
+					inventory.swapPosition(indexes.get(sourceSlot), indexes.get(slot));
+					map.put(slot.getDraggable(), sourceSlot);
 
-                  inventory.swapPosition(indexes.get(sourceSlot), indexes.get(slot));
-                  map.put(slot.getDraggable(), sourceSlot);
+					map.put((Stack) payload.getDragActor(), slot);
 
-                  map.put((Stack) payload.getDragActor(), slot);
+					sourceSlot.setDraggable(slot.getDraggable());
+					slot.setDraggable((Stack) source.getActor());
 
-                  sourceSlot.setDraggable(slot.getDraggable());
-                  slot.setDraggable((Stack) source.getActor());
+					entity.getEvents().trigger("updateToolbar");
+					inventory.setHeldItem(inventory.getHeldIndex());
+				}
+			});
+		}
+	}
 
-                  entity.getEvents().trigger("updateToolbar");
-                  inventory.setHeldItem(inventory.getHeldIndex());
-              }
-          });
-      }
-  }
+	/**
+	 * Get the current window
+	 *
+	 * @return current window
+	 */
+	public Actor getWindow() {
+		return this.window;
+	}
 
-    /**
-     * Get the current window
-     * @return current window
-     */
-    public Actor getWindow() {
-        return this.window;
-    }
+	/**
+	 * The draw stage of the UIComponent, it is handled by the stage
+	 *
+	 * @param batch Batch to render to.
+	 */
+	@Override
+	public void draw(SpriteBatch batch) {
+		// Handled else where
+	}
 
-    /**
-     * The draw stage of the UIComponent, it is handled by the stage
-     * @param batch Batch to render to.
-     */
-    @Override
-    public void draw(SpriteBatch batch) {
-        // Handled else where
-    }
+	/**
+	 * Toggle the inventory open, and changes the window visibility
+	 */
+	public void toggleOpen() {
+		isOpen = !isOpen;
+		window.setVisible(isOpen);
+		inventoryDisplayManager.updateDisplays();
+	}
 
-    /**
-     * Toggle the inventory open, and changes the window visibility
-     */
-    public void toggleOpen(){
-        isOpen = !isOpen;
-        window.setVisible(isOpen);
-        inventoryDisplayManager.updateDisplays();
-    }
+	/**
+	 * Fetches the player inventory and returns it
+	 *
+	 * @return inventory attached to display
+	 */
+	public InventoryComponent getInventory() {
+		return inventory;
+	}
 
-    /**
-     * Fetches the player inventory and returns it
-     * @return inventory attached to display
-     */
-    public InventoryComponent getInventory(){
-        return inventory;
-    }
+	/**
+	 * Fetch the updatedInventory and update display
+	 */
+	public void refreshInventory() {
+		this.inventory = entity.getComponent(InventoryComponent.class);
+		updateInventory();
+		if (this.toolbar) {
+			entity.getEvents().trigger("updateToolbar");
+		}
+	}
 
-    /**
-     * Fetch the updatedInventory and update display
-     */
-    public void refreshInventory(){
-        this.inventory = entity.getComponent(InventoryComponent.class);
-        updateInventory();
-        if (this.toolbar) {
-            entity.getEvents().trigger( "updateToolbar");
-        }
-    }
+	/**
+	 * Dispose of the component
+	 */
+	@Override
+	public void dispose() {
+		inventoryDisplayManager.removeInventoryDisplay(this);
+		super.dispose();
+	}
 
-    /**
-     * Dispose of the component
-     */
-    @Override
-    public void dispose() {
-        inventoryDisplayManager.removeInventoryDisplay(this);
-        super.dispose();
-    }
-
-    public boolean isOpen() {
-        return isOpen;
-    }
+	public boolean isOpen() {
+		return isOpen;
+	}
 }

--- a/source/core/src/main/com/csse3200/game/components/inventory/ItemSlot.java
+++ b/source/core/src/main/com/csse3200/game/components/inventory/ItemSlot.java
@@ -16,198 +16,208 @@ import java.util.Objects;
  * A class used to combine all the data necessary to the individual inventory slots
  */
 public class ItemSlot extends Stack {
-    private static final String SELECTED_PATH = "images/selected.png";
-    private static final String ITEM_FRAME_PATH = "images/itemFrame.png";
-    private Texture itemTexture;
-    private Integer count;
-    private final Skin skin = new Skin(Gdx.files.internal("gardens-of-the-galaxy/gardens-of-the-galaxy.json"));
-    private Image background;
-    private Image frame;
-    private boolean selected;
-    private Image itemImage;
+	private static final String SELECTED_PATH = "images/selected.png";
+	private static final String ITEM_FRAME_PATH = "images/itemFrame.png";
+	private Texture itemTexture;
+	private Integer count;
+	private final Skin skin = ServiceLocator.getResourceService().getAsset("gardens-of-the-galaxy/gardens-of-the-galaxy.json", Skin.class);
+	private Image background;
+	private Image frame;
+	private boolean selected;
+	private Image itemImage;
 
-    private Label label;
-    private Stack draggable;
+	private Label label;
+	private Stack draggable;
 
-    /**
-     * Construct an itemSlot with a texture, count and selected state
-     * @param itemTexture texture of item's image
-     * @param count count of item
-     * @param selected boolean state of whether item slot is selected
-     */
-    public ItemSlot(Texture itemTexture, Integer count, boolean selected) {
-        this.itemTexture = itemTexture;
-        this.count = count;
-        this.background = new Image(ServiceLocator.getResourceService().getAsset(SELECTED_PATH, Texture.class));
-        this.frame = new Image(ServiceLocator.getResourceService().getAsset(ITEM_FRAME_PATH, Texture.class));
-        this.selected = selected;
-        this.createItemSlot();
-    }
+	/**
+	 * Construct an itemSlot with a texture, count and selected state
+	 *
+	 * @param itemTexture texture of item's image
+	 * @param count       count of item
+	 * @param selected    boolean state of whether item slot is selected
+	 */
+	public ItemSlot(Texture itemTexture, Integer count, boolean selected) {
+		this.itemTexture = itemTexture;
+		this.count = count;
+		this.background = new Image(ServiceLocator.getResourceService().getAsset(SELECTED_PATH, Texture.class));
+		this.frame = new Image(ServiceLocator.getResourceService().getAsset(ITEM_FRAME_PATH, Texture.class));
+		this.selected = selected;
+		this.createItemSlot();
+	}
 
-    /**
-     * Construct an itemSlot with a texture and selected state
-     * @param itemTexture texture of item's image
-     * @param selected boolean state of whether item slot is selected
-     */
-    public ItemSlot(Texture itemTexture, boolean selected) {
-        this.itemTexture = itemTexture;
-        this.count = null;
-        this.background = new Image(ServiceLocator.getResourceService().getAsset(SELECTED_PATH, Texture.class));
-        this.frame = new Image(ServiceLocator.getResourceService().getAsset(ITEM_FRAME_PATH, Texture.class));
-        this.selected = selected;
-        this.createItemSlot();
-    }
+	/**
+	 * Construct an itemSlot with a texture and selected state
+	 *
+	 * @param itemTexture texture of item's image
+	 * @param selected    boolean state of whether item slot is selected
+	 */
+	public ItemSlot(Texture itemTexture, boolean selected) {
+		this.itemTexture = itemTexture;
+		this.count = null;
+		this.background = new Image(ServiceLocator.getResourceService().getAsset(SELECTED_PATH, Texture.class));
+		this.frame = new Image(ServiceLocator.getResourceService().getAsset(ITEM_FRAME_PATH, Texture.class));
+		this.selected = selected;
+		this.createItemSlot();
+	}
 
-    /**
-     * Construct an itemSlot with a selected state
-     * @param selected boolean state of whether item slot is selected
-     */
-    public ItemSlot(boolean selected) {
-        this.itemTexture = null;
-        this.count = null;
-        this.background = new Image(ServiceLocator.getResourceService().getAsset(SELECTED_PATH, Texture.class));
-        this.frame = new Image(ServiceLocator.getResourceService().getAsset(ITEM_FRAME_PATH, Texture.class));
-        this.selected = selected;
-        this.createItemSlot();
+	/**
+	 * Construct an itemSlot with a selected state
+	 *
+	 * @param selected boolean state of whether item slot is selected
+	 */
+	public ItemSlot(boolean selected) {
+		this.itemTexture = null;
+		this.count = null;
+		this.background = new Image(ServiceLocator.getResourceService().getAsset(SELECTED_PATH, Texture.class));
+		this.frame = new Image(ServiceLocator.getResourceService().getAsset(ITEM_FRAME_PATH, Texture.class));
+		this.selected = selected;
+		this.createItemSlot();
 
-    }
+	}
 
-    /**
-     * Set the item count
-     * @param count integer of number of item
-     */
-    public void setCount(Integer count) {
-        if (Objects.equals(count, this.count)) {
-            return;
-        }
-        this.count = count;
-        if (this.count > 1) {
-            if (label == null) {
-                label = new Label(this.count + " ", this.skin);
-                label.setColor(Color.BLACK);
-                label.setAlignment(Align.bottomRight);
-                draggable.add(label);
-            } else {
-                label.setText(this.count + " ");
-                draggable.add(label);
+	/**
+	 * Set the item count
+	 *
+	 * @param count integer of number of item
+	 */
+	public void setCount(Integer count) {
+		if (Objects.equals(count, this.count)) {
+			return;
+		}
+		this.count = count;
+		if (this.count > 1) {
+			if (label == null) {
+				label = new Label(this.count + " ", this.skin);
+				label.setColor(Color.BLACK);
+				label.setAlignment(Align.bottomRight);
+				draggable.add(label);
+			} else {
+				label.setText(this.count + " ");
+				draggable.add(label);
 
-            }
-        }
-        else {
-            draggable.removeActor(label);
-            if (label != null) {
-                this.label = null;
+			}
+		} else {
+			draggable.removeActor(label);
+			if (label != null) {
+				this.label = null;
 
-            }
-        }
-    }
-    /**
-     * Get the item count
-     * @return count integer of number of item
-     */
-    public Integer getCount() {
-        if (count != null) {
-            return count;
-        }
-        return -1;
-    }
+			}
+		}
+	}
 
-    /**
-     * Set the item texture
-     * @return  itemTexture texture of item's image
-     */
-    public Texture getItemTexture() {
-        return this.itemTexture;
-    }
+	/**
+	 * Get the item count
+	 *
+	 * @return count integer of number of item
+	 */
+	public Integer getCount() {
+		if (count != null) {
+			return count;
+		}
+		return -1;
+	}
 
-    @Override
-    public String toString() {
-        return super.toString();
-    }
+	/**
+	 * Set the item texture
+	 *
+	 * @return itemTexture texture of item's image
+	 */
+	public Texture getItemTexture() {
+		return this.itemTexture;
+	}
 
-    /**
-     * Creates the itemSlot
-     */
-    private void createItemSlot() {
-        draggable = new Stack();
+	@Override
+	public String toString() {
+		return super.toString();
+	}
 
-        //Add the selection background if necessary
-        if (this.selected) {
-            this.add(this.background);
-        }
+	/**
+	 * Creates the itemSlot
+	 */
+	private void createItemSlot() {
+		draggable = new Stack();
 
-        //Add the item frame image to the item slot
-        this.add(this.frame);
+		//Add the selection background if necessary
+		if (this.selected) {
+			this.add(this.background);
+		}
 
-        //Add the item image to the itemSlot
-        if (this.itemTexture != null) {
-            itemImage = new Image(this.itemTexture);
-            draggable.add(itemImage);
-        }
+		//Add the item frame image to the item slot
+		this.add(this.frame);
 
-        // Add or update the count label if the number is not 0
-        if (this.count != null && this.count > 1) {
-            if (label == null) {
-                label = new Label(this.count + " ", this.skin);
-                label.setColor(Color.BLACK);
-                label.setAlignment(Align.bottomRight);
-                draggable.add(label);
-            } else {
-                label.setText(this.count + " ");
-            }
-        }
-        if (this.count != null && this.count <= 1 && label != null) {
-            draggable.removeActor(label);
-            this.label = null;
-        }
+		//Add the item image to the itemSlot
+		if (this.itemTexture != null) {
+			itemImage = new Image(this.itemTexture);
+			draggable.add(itemImage);
+		}
 
-        this.add(draggable);
+		// Add or update the count label if the number is not 0
+		if (this.count != null && this.count > 1) {
+			if (label == null) {
+				label = new Label(this.count + " ", this.skin);
+				label.setColor(Color.BLACK);
+				label.setAlignment(Align.bottomRight);
+				draggable.add(label);
+			} else {
+				label.setText(this.count + " ");
+			}
+		}
+		if (this.count != null && this.count <= 1 && label != null) {
+			draggable.removeActor(label);
+			this.label = null;
+		}
 
-    }
+		this.add(draggable);
 
-    /**
-     * Get the item image
-     * @return the item image
-     */
-    public Image getItemImage() {
-        return itemImage;
-    }
-    public Stack getDraggable() {
-        return draggable;
-    }
-    public boolean setDraggable(Stack stack) {
-        boolean ans = false;
-        if (!this.removeActor(this.draggable)) {
-            ans = true;
-        }
+	}
 
-        if (stack != null) {
-            this.draggable = stack;
-            this.add(stack);
-        }
-        return ans;
-    }
-    public void setItemImage(Image image) {
-        draggable.removeActor(itemImage);
-        if (image != null) {
-            draggable.addActorAt(0, image);
-            this.itemImage = image;
-        }
-    }
+	/**
+	 * Get the item image
+	 *
+	 * @return the item image
+	 */
+	public Image getItemImage() {
+		return itemImage;
+	}
 
-    /**
-     * Make the slot selected
-     */
-    public void setSelected() {
-        selected = true;
-        this.addActorAt(0, this.background);
-    }
+	public Stack getDraggable() {
+		return draggable;
+	}
 
-    /**
-     * Make the slot unselected
-     */
-    public void setUnselected() {
-        selected = false;
-        this.removeActor(this.background);
-    }
+	public boolean setDraggable(Stack stack) {
+		boolean ans = false;
+		if (!this.removeActor(this.draggable)) {
+			ans = true;
+		}
+
+		if (stack != null) {
+			this.draggable = stack;
+			this.add(stack);
+		}
+		return ans;
+	}
+
+	public void setItemImage(Image image) {
+		draggable.removeActor(itemImage);
+		if (image != null) {
+			draggable.addActorAt(0, image);
+			this.itemImage = image;
+		}
+	}
+
+	/**
+	 * Make the slot selected
+	 */
+	public void setSelected() {
+		selected = true;
+		this.addActorAt(0, this.background);
+	}
+
+	/**
+	 * Make the slot unselected
+	 */
+	public void setUnselected() {
+		selected = false;
+		this.removeActor(this.background);
+	}
 }

--- a/source/core/src/main/com/csse3200/game/components/inventory/ItemSlot.java
+++ b/source/core/src/main/com/csse3200/game/components/inventory/ItemSlot.java
@@ -8,14 +8,16 @@ import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.Stack;
 import com.badlogic.gdx.utils.Align;
+import com.csse3200.game.services.ServiceLocator;
+
 import java.util.Objects;
 
 /**
  * A class used to combine all the data necessary to the individual inventory slots
  */
 public class ItemSlot extends Stack {
-    private static final String selectedString = "images/selected.png";
-    private static final String itemFrameString = "images/itemFrame.png";
+    private static final String SELECTED_PATH = "images/selected.png";
+    private static final String ITEM_FRAME_PATH = "images/itemFrame.png";
     private Texture itemTexture;
     private Integer count;
     private final Skin skin = new Skin(Gdx.files.internal("gardens-of-the-galaxy/gardens-of-the-galaxy.json"));
@@ -36,8 +38,8 @@ public class ItemSlot extends Stack {
     public ItemSlot(Texture itemTexture, Integer count, boolean selected) {
         this.itemTexture = itemTexture;
         this.count = count;
-        this.background = new Image(new Texture(Gdx.files.internal(selectedString)));
-        this.frame = new Image(new Texture(Gdx.files.internal(itemFrameString)));
+        this.background = new Image(ServiceLocator.getResourceService().getAsset(SELECTED_PATH, Texture.class));
+        this.frame = new Image(ServiceLocator.getResourceService().getAsset(ITEM_FRAME_PATH, Texture.class));
         this.selected = selected;
         this.createItemSlot();
     }
@@ -50,8 +52,8 @@ public class ItemSlot extends Stack {
     public ItemSlot(Texture itemTexture, boolean selected) {
         this.itemTexture = itemTexture;
         this.count = null;
-        this.background = new Image(new Texture(Gdx.files.internal(selectedString)));
-        this.frame = new Image(new Texture(Gdx.files.internal(itemFrameString)));
+        this.background = new Image(ServiceLocator.getResourceService().getAsset(SELECTED_PATH, Texture.class));
+        this.frame = new Image(ServiceLocator.getResourceService().getAsset(ITEM_FRAME_PATH, Texture.class));
         this.selected = selected;
         this.createItemSlot();
     }
@@ -63,8 +65,8 @@ public class ItemSlot extends Stack {
     public ItemSlot(boolean selected) {
         this.itemTexture = null;
         this.count = null;
-        this.background = new Image(new Texture(Gdx.files.internal(selectedString)));
-        this.frame = new Image(new Texture(Gdx.files.internal(itemFrameString)));
+        this.background = new Image(ServiceLocator.getResourceService().getAsset(SELECTED_PATH, Texture.class));
+        this.frame = new Image(ServiceLocator.getResourceService().getAsset(ITEM_FRAME_PATH, Texture.class));
         this.selected = selected;
         this.createItemSlot();
 

--- a/source/core/src/main/com/csse3200/game/components/inventory/ToolbarDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/inventory/ToolbarDisplay.java
@@ -12,6 +12,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Window;
 import com.badlogic.gdx.utils.Align;
 import com.csse3200.game.components.items.ItemComponent;
 import com.csse3200.game.components.player.InventoryComponent;
+import com.csse3200.game.services.ServiceLocator;
 import com.csse3200.game.ui.UIComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +25,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Image;
  */
 public class ToolbarDisplay extends UIComponent {
     private static final Logger logger = LoggerFactory.getLogger(ToolbarDisplay.class);
-    private final Skin skin = new Skin(Gdx.files.internal("gardens-of-the-galaxy/gardens-of-the-galaxy.json"));
+    private final Skin skin = ServiceLocator.getResourceService().getAsset("gardens-of-the-galaxy/gardens-of-the-galaxy.json", Skin.class);
     private final Table table = new Table(skin);
     private final Window window = new Window("", skin);
     private boolean isOpen;

--- a/source/core/src/main/com/csse3200/game/components/items/ItemComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/items/ItemComponent.java
@@ -150,10 +150,10 @@ public class ItemComponent extends Component {
 	/**
 	 * Sets an Item's texture component to a given Texture
 	 *
-	 * @param itemTexture - The texture to set the item to.
+	 * @param texturePath - path of the new item texture
 	 */
-	public void setItemTexture(Texture itemTexture) {
-		this.itemTexture = itemTexture;
+	public void setItemTexture(String texturePath) {
+		this.itemTexture = ServiceLocator.getResourceService().getAsset(texturePath, Texture.class);
 	}
 
 	/**

--- a/source/core/src/main/com/csse3200/game/components/items/ItemComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/items/ItemComponent.java
@@ -4,217 +4,238 @@ import java.util.UUID;
 
 import com.badlogic.gdx.graphics.Texture;
 import com.csse3200.game.components.Component;
+import com.csse3200.game.services.ServiceLocator;
 
 
 public class ItemComponent extends Component {
-    /**
-     * Item class for all items in the game
-     * @param itemName user facing name for item
-     * @param itemDescription user facing description for item
-     * @param price price of item
-     * @param sellable is the item sellable. true if sellable false otherwise
-     * @param itemId unique id of the item
-     * @param itemType type of item
-     *
-     */
-    private String itemName; // User facing name for item. can be customised by user.
-    private String itemDescription; // User facing description for item.
-    private final String itemId;
-    private int price; // Price of item
-    private final boolean sellable; // is the item sellable
-    private final ItemType itemType; // Type of item
-    private Texture itemTexture;
+	/**
+	 * Item class for all items in the game
+	 *
+	 * @param itemName user facing name for item
+	 * @param itemDescription user facing description for item
+	 * @param price price of item
+	 * @param sellable is the item sellable. true if sellable false otherwise
+	 * @param itemId unique id of the item
+	 * @param itemType type of item
+	 */
+	private String itemName; // User facing name for item. can be customised by user.
+	private String itemDescription; // User facing description for item.
+	private final String itemId;
+	private int price; // Price of item
+	private final boolean sellable; // is the item sellable
+	private final ItemType itemType; // Type of item
+	private Texture itemTexture;
 
-    private final boolean perishable; // will the item be consumed on use
-
-
-    /**
-     * Constructor for Item
-     * @param itemName user facing name for item
-     * @param itemType the enum for type of item
-     */
-    public ItemComponent(String itemName, ItemType itemType, Texture invSprite) {
-        this.itemTexture = invSprite;
-        this.itemType = itemType;
-        this.itemName = itemName;
-        this.itemId = generateUniqueID(); // Generate a unique ID for the item
-        this.itemDescription = "" ; //default description
-        this.price = 0;
-        this.sellable = false; //default sellable
-        this.perishable = false;
-    }
-    public ItemComponent(String itemName, ItemType itemType, Texture invSprite, boolean perishable) {
-        this.itemTexture = invSprite;
-        this.itemType = itemType;
-        this.itemName = itemName;
-        this.itemId = generateUniqueID(); // Generate a unique ID for the item
-        this.itemDescription = "" ; //default description
-        this.price = 0;
-        this.sellable = false; //default sellable
-        this.perishable = perishable;
-    }
-
-    /**
-     * Constructor for Item
-     * @param itemName user facing name
-     * @param itemType the enum for type of item
-     * @param price sellable price of the item
-     */
-    public ItemComponent(String itemName, ItemType itemType, int price, Texture invSprite) {
-        this.itemTexture = invSprite;
-        this.itemType = itemType;
-        this.itemName = itemName;
-        this.itemId = generateUniqueID(); // Generate a unique ID for the item
-        this.itemDescription = "" ; //default description
-        this.price = price;
-        this.sellable = true;
-        this.perishable = false;
-    }
-
-    /**
-     * Constructor for Item
-     * @param itemName user facing name for item
-     * @param itemType the enum for type of item
-     * @param itemDescription user facing description for item
-     */
-    public ItemComponent(String itemName, ItemType itemType, String itemDescription, Texture itemTexture) {
-        this.itemTexture = itemTexture;
-        this.itemType = itemType;
-        this.itemName = itemName;
-        this.itemId = generateUniqueID(); // Generate a unique ID for the item
-        this.itemDescription = itemDescription ; //default description
-        this.sellable = false; //default sellable
-        this.perishable = false;
-    }
-    public ItemComponent(String itemName, ItemType itemType, String itemDescription, Texture itemTexture, boolean perishable) {
-        this.itemTexture = itemTexture;
-        this.itemType = itemType;
-        this.itemName = itemName;
-        this.itemId = generateUniqueID(); // Generate a unique ID for the item
-        this.itemDescription = itemDescription ; //default description
-        this.sellable = false; //default sellable
-        this.perishable = perishable;
-    }
-
-    /**
-     * Constructor for Item
-     * @param itemName user facing name for item
-     * @param itemType the enum for type of item
-     * @param itemDescription user facing description for item
-     * @param price price of item
-     */
-    public ItemComponent(String itemName, ItemType itemType, String itemDescription, int price, Texture invSprite) {
-        this.itemTexture = invSprite;
-        this.itemType = itemType;
-        this.itemName = itemName;
-        this.itemId = generateUniqueID(); // Generate a unique ID for the item
-        this.itemDescription = itemDescription ; //default description
-        this.price = price;
-        this.sellable = true;
-        this.perishable = false;
-    }
-
-    /**
-     * Returns if the item is consumable
-     * @return boolean whether the item is perishable or not
-     */
-    public boolean isPerishable() {
-        return perishable;
-    }
-    /**
-     * Returns the price of the item
-     * @return int price of item
-     */
-    public int getPrice() {
-        return price;
-    }
-
-    /**
-     * Sets the price of the item
-     * @param price int price of item
-     */
-    public void setPrice(int price) {
-        this.price = price;
-    }
-
-    /**
-     * @return the texture of the item (Primarily used to the inventory display)
-     */
-    public Texture getItemTexture() {
-        return this.itemTexture;
-    }
-
-    /**
-     * Sets an Item's texture component to a given Texture
-     *
-     * @param itemTexture - The texture to set the item to.
-     */
-    public void setItemTexture(Texture itemTexture) {
-        this.itemTexture = itemTexture;
-    }
-
-    /**
-     * Returns selalble bool of item
-     * @return true if item is sellable, false otherwise
-     */
-    public boolean isSellable() {
-        return sellable;
-    }
+	private final boolean perishable; // will the item be consumed on use
 
 
-    /**
-     * Returns the name of the item
-     * @return int price of item
-     */
-    public String getItemName() {
-        return itemName;
-    }
+	/**
+	 * Constructor for Item
+	 *
+	 * @param itemName user facing name for item
+	 * @param itemType the enum for type of item
+	 * @param texturePath path for the item texture
+	 */
+	public ItemComponent(String itemName, ItemType itemType, String texturePath) {
+		this(itemName, itemType, "", 0, false, false, texturePath);
+	}
 
-    /**
-     * Returns the id of the item
-     * @return String id of item
-     */
-    public String getItemId() {
-        return itemId;
-    }
+	/**
+	 * Constructor for Item
+	 *
+	 * @param itemName user facing name for item
+	 * @param itemType the enum for type of item
+	 * @param perishable whether the item is perishable
+	 * @param texturePath path for the item texture
+	 */
+	public ItemComponent(String itemName, ItemType itemType, String texturePath, boolean perishable) {
+		this(itemName, itemType, "", 0, false, perishable, texturePath);
+	}
 
-    /**
-     * Returns the description of the item
-     * @return String description of item
-     */
-    public String getItemDescription() {
-        return itemDescription;
-    }
+	/**
+	 * Constructor for Item
+	 *
+	 * @param itemName user facing name
+	 * @param itemType the enum for type of item
+	 * @param price    sellable price of the item
+	 * @param texturePath path for the item texture
+	 */
+	public ItemComponent(String itemName, ItemType itemType, int price, String texturePath) {
+		this(itemName, itemType, "", price, true, false, texturePath);
+	}
 
-    /**
-     * Sets the price of the item
-     * @param description string description of the item
-     */
-    public void setItemDescription(String description) {
-        itemDescription = description;
-    }
+	/**
+	 * Constructor for Item
+	 *
+	 * @param itemName        user facing name for item
+	 * @param itemType        the enum for type of item
+	 * @param itemDescription user facing description for item
+	 * @param texturePath path for the item texture
+	 */
+	public ItemComponent(String itemName, ItemType itemType, String itemDescription, String texturePath) {
+		this(itemName, itemType, itemDescription, 0, false, false, texturePath);
+	}
 
-    /**
-     * Sets the item name of the item
-     * @param name string name of the item
-     */
-    public void setItemName(String name) {
-        itemName = name;
-    }
+	/**
+	 * Constructor for Item
+	 *
+	 * @param itemName        user facing name for item
+	 * @param itemType        the enum for type of item
+	 * @param itemDescription user facing description for item
+	 * @param perishable whether the item is perishable
+	 * @param texturePath path for the item texture
+	 */
+	public ItemComponent(String itemName, ItemType itemType, String itemDescription, boolean perishable, String texturePath) {
+		this(itemName, itemType, itemDescription, 0, false, perishable, texturePath);
+	}
 
-    /**
-     * Returns the type of the item
-     * @return ItemType enum type of item
-     */
-    public ItemType getItemType() {
-        return itemType;
-    }
+	/**
+	 * Constructor for Item
+	 *
+	 * @param itemName        user facing name for item
+	 * @param itemType        the enum for type of item
+	 * @param itemDescription user facing description for item
+	 * @param price           price of item
+	 * @param texturePath path for the item texture
+	 */
+	public ItemComponent(String itemName, ItemType itemType, String itemDescription, int price, String texturePath) {
+		this(itemName, itemType, itemDescription, price, true, false, texturePath);
+	}
 
-    /**
-     * Generates a unique ID for the item
-     * @return String random unique ID for each item
-     */
-    private String generateUniqueID() {
-        return UUID.randomUUID().toString();
-    }
+	/**
+	 *
+	 * @param itemName        user facing name for item
+	 * @param itemType        the enum for type of item
+	 * @param itemDescription user facing description for item
+	 * @param price           price of item
+	 * @param sellable        whether the item is sellable
+	 * @param perishable      whether the item is perishable
+	 * @param texturePath     path for the item texture
+	 */
+	private ItemComponent(String itemName, ItemType itemType, String itemDescription, int price, boolean sellable, boolean perishable, String texturePath) {
+		this.itemTexture = ServiceLocator.getResourceService().getAsset(texturePath, Texture.class);
+		this.itemType = itemType;
+		this.itemName = itemName;
+		this.itemId = generateUniqueID(); // Generate a unique ID for the item
+		this.itemDescription = itemDescription; //default description
+		this.price = price;
+		this.sellable = sellable;
+		this.perishable = perishable;
+	}
+
+	/**
+	 * Returns if the item is consumable
+	 *
+	 * @return boolean whether the item is perishable or not
+	 */
+	public boolean isPerishable() {
+		return perishable;
+	}
+
+	/**
+	 * Returns the price of the item
+	 *
+	 * @return int price of item
+	 */
+	public int getPrice() {
+		return price;
+	}
+
+	/**
+	 * Sets the price of the item
+	 *
+	 * @param price int price of item
+	 */
+	public void setPrice(int price) {
+		this.price = price;
+	}
+
+	/**
+	 * @return the texture of the item (Primarily used to the inventory display)
+	 */
+	public Texture getItemTexture() {
+		return this.itemTexture;
+	}
+
+	/**
+	 * Sets an Item's texture component to a given Texture
+	 *
+	 * @param itemTexture - The texture to set the item to.
+	 */
+	public void setItemTexture(Texture itemTexture) {
+		this.itemTexture = itemTexture;
+	}
+
+	/**
+	 * Returns selalble bool of item
+	 *
+	 * @return true if item is sellable, false otherwise
+	 */
+	public boolean isSellable() {
+		return sellable;
+	}
+
+
+	/**
+	 * Returns the name of the item
+	 *
+	 * @return int price of item
+	 */
+	public String getItemName() {
+		return itemName;
+	}
+
+	/**
+	 * Returns the id of the item
+	 *
+	 * @return String id of item
+	 */
+	public String getItemId() {
+		return itemId;
+	}
+
+	/**
+	 * Returns the description of the item
+	 *
+	 * @return String description of item
+	 */
+	public String getItemDescription() {
+		return itemDescription;
+	}
+
+	/**
+	 * Sets the price of the item
+	 *
+	 * @param description string description of the item
+	 */
+	public void setItemDescription(String description) {
+		itemDescription = description;
+	}
+
+	/**
+	 * Sets the item name of the item
+	 *
+	 * @param name string name of the item
+	 */
+	public void setItemName(String name) {
+		itemName = name;
+	}
+
+	/**
+	 * Returns the type of the item
+	 *
+	 * @return ItemType enum type of item
+	 */
+	public ItemType getItemType() {
+		return itemType;
+	}
+
+	/**
+	 * Generates a unique ID for the item
+	 *
+	 * @return String random unique ID for each item
+	 */
+	private String generateUniqueID() {
+		return UUID.randomUUID().toString();
+	}
 }

--- a/source/core/src/main/com/csse3200/game/components/items/ItemComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/items/ItemComponent.java
@@ -8,16 +8,6 @@ import com.csse3200.game.services.ServiceLocator;
 
 
 public class ItemComponent extends Component {
-	/**
-	 * Item class for all items in the game
-	 *
-	 * @param itemName user facing name for item
-	 * @param itemDescription user facing description for item
-	 * @param price price of item
-	 * @param sellable is the item sellable. true if sellable false otherwise
-	 * @param itemId unique id of the item
-	 * @param itemType type of item
-	 */
 	private String itemName; // User facing name for item. can be customised by user.
 	private String itemDescription; // User facing description for item.
 	private final String itemId;

--- a/source/core/src/main/com/csse3200/game/entities/factories/ItemFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/ItemFactory.java
@@ -67,7 +67,7 @@ public class ItemFactory {
     Entity shovel = createBaseItem()
         .addComponent(new TextureRenderComponent("images/tool_shovel.png"))
         .addComponent(new ItemComponent("shovel", ItemType.SHOVEL, "Shovel for removing items",
-            new Texture("images/tool_shovel.png")));
+            "images/tool_shovel.png"));
     return shovel;
   }
 
@@ -79,7 +79,7 @@ public class ItemFactory {
   public static Entity createHoe() {
     Entity hoe = createBaseItem()
         .addComponent(new TextureRenderComponent("images/tool_hoe.png"))
-        .addComponent(new ItemComponent("hoe", ItemType.HOE, new Texture("images/tool_hoe.png")));
+        .addComponent(new ItemComponent("hoe", ItemType.HOE, "images/tool_hoe.png"));
     return hoe;
   }
 
@@ -92,7 +92,7 @@ public class ItemFactory {
     Entity wateringCan = createBaseItem()
         .addComponent(new TextureRenderComponent("images/tool_watering_can.png"))
         .addComponent(
-            new ItemComponent("watering_can", ItemType.WATERING_CAN, new Texture("images/tool_watering_can.png")))
+            new ItemComponent("watering_can", ItemType.WATERING_CAN, "images/tool_watering_can.png"))
         .addComponent(new WateringCanLevelComponent(150));
     return wateringCan;
   }
@@ -105,7 +105,7 @@ public class ItemFactory {
   public static Entity createScythe() {
     Entity scythe = createBaseItem()
         .addComponent(new TextureRenderComponent("images/tool_scythe.png"))
-        .addComponent(new ItemComponent("scythe", ItemType.SCYTHE, new Texture("images/tool_scythe.png")));
+        .addComponent(new ItemComponent("scythe", ItemType.SCYTHE, "images/tool_scythe.png"));
     return scythe;
   }
 
@@ -117,7 +117,7 @@ public class ItemFactory {
   public static Entity createSword() {
     Entity sword = createBaseItem()
             .addComponent(new TextureRenderComponent("images/tool_sword.png"))
-            .addComponent(new ItemComponent("sword", ItemType.SWORD, new Texture("images/tool_sword.png")));
+            .addComponent(new ItemComponent("sword", ItemType.SWORD, "images/tool_sword.png"));
     return sword;
   }
 
@@ -129,7 +129,7 @@ public class ItemFactory {
   public static Entity createGun() {
     Entity gun = createBaseItem()
             .addComponent(new TextureRenderComponent("images/tool_gun.png"))
-            .addComponent(new ItemComponent("gun", ItemType.GUN, new Texture("images/tool_gun.png")));
+            .addComponent(new ItemComponent("gun", ItemType.GUN, "images/tool_gun.png"));
     return gun;
   }
 
@@ -142,7 +142,7 @@ public class ItemFactory {
     Entity milk = createBaseItem()
             .addComponent(new TextureRenderComponent("images/animals/milk.png"))
             .addComponent(new ItemComponent("milk",
-                    ItemType.MILK, new Texture("images/animals/milk.png")));
+                    ItemType.MILK, "images/animals/milk.png"));
     milk.scaleHeight(0.75f);
     return milk;
   }
@@ -156,7 +156,7 @@ public class ItemFactory {
     Entity egg = createBaseItem()
             .addComponent(new TextureRenderComponent("images/animals/egg.png"))
             .addComponent(new ItemComponent("egg", ItemType.EGG,
-                    new Texture("images/animals/egg.png")));
+                    "images/animals/egg.png"));
     egg.scaleHeight(0.75f);
     return egg;
   }
@@ -170,7 +170,7 @@ public class ItemFactory {
     Entity egg = createBaseItem()
             .addComponent(new TextureRenderComponent("images/animals/golden_egg.png"))
             .addComponent(new ItemComponent("golden egg", ItemType.EGG,
-                    new Texture("images/animals/golden_egg.png")));
+                    "images/animals/golden_egg.png"));
     egg.scaleHeight(0.75f);
     return egg;
   }
@@ -184,7 +184,7 @@ public class ItemFactory {
     ClueComponent clueComponent = new ClueComponent();
     Entity mapItem = createBaseItem()
             .addComponent(new TextureRenderComponent("images/ship/ship_clue.png"))
-            .addComponent(new ItemComponent("map", ItemType.CLUE_ITEM, new Texture("images/ship/ship_clue.png")))
+            .addComponent(new ItemComponent("map", ItemType.CLUE_ITEM, "images/ship/ship_clue.png"))
             .addComponent(clueComponent)
             .addComponent(new CoordinatesDisplay(clueComponent));
 
@@ -200,7 +200,7 @@ public class ItemFactory {
     Entity fertiliser = createBaseItem()
             .addComponent(new TextureRenderComponent("images/fertiliser.png"))
             .addComponent(new ItemComponent("fertiliser", ItemType.FERTILISER,
-                    new Texture("images/fertiliser.png")));
+                    "images/fertiliser.png"));
     return fertiliser;
   }
 
@@ -213,7 +213,7 @@ public class ItemFactory {
     Entity seed = createBaseItem()
             .addComponent(new TextureRenderComponent("images/plants/aloe_vera/seedbag.png"))
             .addComponent(new ItemComponent("Aloe Vera Seeds", ItemType.SEED,
-                    "Seed of Aloe Vera", new Texture("images/plants/aloe_vera/seedbag.png")));
+                    "Seed of Aloe Vera", "images/plants/aloe_vera/seedbag.png"));
     return seed;
   }
 
@@ -227,7 +227,7 @@ public class ItemFactory {
             .addComponent(new TextureRenderComponent("images/plants/aloe_vera/item_drop.png"))
             .addComponent(new ItemComponent("Aloe Vera Leaf", ItemType.FOOD,
                     "The gel oozing from this leaf has mystical healing properties",
-                    new Texture("images/plants/aloe_vera/item_drop.png")));
+                    "images/plants/aloe_vera/item_drop.png"));
     return itemDrop;
   }
 
@@ -240,7 +240,7 @@ public class ItemFactory {
     Entity seed = createBaseItem()
             .addComponent(new TextureRenderComponent("images/plants/atomic_algae/seedbag.png"))
             .addComponent(new ItemComponent("Atomic Algae Seeds", ItemType.SEED,
-                    "Seed of Atomic Algae", new Texture("images/plants/atomic_algae/seedbag.png")));
+                    "Seed of Atomic Algae", "images/plants/atomic_algae/seedbag.png"));
     return seed;
   }
 
@@ -253,7 +253,7 @@ public class ItemFactory {
     Entity seed = createBaseItem()
             .addComponent(new TextureRenderComponent("images/plants/cosmic_cob/seedbag.png"))
             .addComponent(new ItemComponent("Cosmic Cob Seeds", ItemType.SEED,
-                    "Seed of Cosmic Cob", new Texture("images/plants/cosmic_cob/seedbag.png")));
+                    "Seed of Cosmic Cob", "images/plants/cosmic_cob/seedbag.png"));
     return seed;
   }
 
@@ -267,7 +267,7 @@ public class ItemFactory {
             .addComponent(new TextureRenderComponent("images/plants/cosmic_cob/item_drop.png"))
             .addComponent(new ItemComponent("Ear of Cosmic Cob", ItemType.FOOD,
                     "Nutritious space corn essential for surviving out in space",
-                    new Texture("images/plants/cosmic_cob/item_drop.png")));
+                    "images/plants/cosmic_cob/item_drop.png"));
     return itemDrop;
   }
 
@@ -280,7 +280,7 @@ public class ItemFactory {
     Entity seed = createBaseItem()
             .addComponent(new TextureRenderComponent("images/plants/deadly_nightshade/seedbag.png"))
             .addComponent(new ItemComponent("Deadly Nightshade Seeds", ItemType.SEED,
-                    "Seed of Deadly Nightshade", new Texture("images/plants/deadly_nightshade/seedbag.png")));
+                    "Seed of Deadly Nightshade", "images/plants/deadly_nightshade/seedbag.png"));
     return seed;
   }
 
@@ -294,7 +294,7 @@ public class ItemFactory {
             .addComponent(new TextureRenderComponent("images/plants/deadly_nightshade/item_drop.png"))
             .addComponent(new ItemComponent("Nightshade Berry", ItemType.FOOD,
                     "Deadly poisonous to humans, but the local wildlife find it delectable",
-                    new Texture("images/plants/deadly_nightshade/item_drop.png")));
+                    "images/plants/deadly_nightshade/item_drop.png"));
     return itemDrop;
   }
 
@@ -307,7 +307,7 @@ public class ItemFactory {
     Entity seed = createBaseItem()
             .addComponent(new TextureRenderComponent("images/plants/hammer_plant/seedbag.png"))
             .addComponent(new ItemComponent("Hammer Plant Seeds", ItemType.SEED,
-                    "Seed of Hammer Plant", new Texture("images/plants/hammer_plant/seedbag.png")));
+                    "Seed of Hammer Plant", "images/plants/hammer_plant/seedbag.png"));
     return seed;
   }
 
@@ -321,7 +321,7 @@ public class ItemFactory {
             .addComponent(new TextureRenderComponent("images/plants/hammer_plant/item_drop.png"))
             .addComponent(new ItemComponent("Hammer Flower", ItemType.FOOD,
                     "Unusually shaped flower that looks like the tool it is named after",
-                    new Texture("images/plants/hammer_plant/item_drop.png")));
+                    "images/plants/hammer_plant/item_drop.png"));
     return itemDrop;
   }
 
@@ -334,7 +334,7 @@ public class ItemFactory {
     Entity seed = createBaseItem()
             .addComponent(new TextureRenderComponent("images/plants/space_snapper/seedbag.png"))
             .addComponent(new ItemComponent("Space Snapper Seeds", ItemType.SEED,
-                    "Seed of Space Snapper", new Texture("images/plants/space_snapper/seedbag.png")));
+                    "Seed of Space Snapper", "images/plants/space_snapper/seedbag.png"));
     return seed;
   }
 
@@ -347,7 +347,7 @@ public class ItemFactory {
     Entity animalFood = createBaseItem()
             .addComponent(new TextureRenderComponent("images/animals/beef.png"))
             .addComponent(new ItemComponent("Beef", ItemType.FOOD,
-                    "Beef", new Texture("images/animals/beef.png")));
+                    "Beef", "images/animals/beef.png"));
     return animalFood;
   }
 
@@ -360,7 +360,7 @@ public class ItemFactory {
     Entity chickenMeat = createBaseItem()
             .addComponent(new TextureRenderComponent("images/animals/chicken_meat.png"))
             .addComponent(new ItemComponent("Chicken", ItemType.FOOD,
-                    "Chicken", new Texture("images/animals/chicken_meat.png")));
+                    "Chicken", "images/animals/chicken_meat.png"));
     chickenMeat.scaleHeight(0.6f);
     return chickenMeat;
   }
@@ -374,7 +374,7 @@ public class ItemFactory {
             .addComponent(new TextureRenderComponent("images/placeable/fences/f.png"))
             .addComponent(new ItemComponent("Fence", ItemType.PLACEABLE,
                     "A fence to keep animals in or out",
-                    new Texture("images/placeable/fences/f.png")));
+                    "images/placeable/fences/f.png"));
     return fence;
   }
 
@@ -387,7 +387,7 @@ public class ItemFactory {
             .addComponent(new TextureRenderComponent("images/placeable/fences/g_r_l.png"))
             .addComponent(new ItemComponent("Gate", ItemType.PLACEABLE,
                     "Allows the player to walk in and out of enclosed areas",
-                    new Texture("images/placeable/fences/g_r_l.png")));
+                    "images/placeable/fences/g_r_l.png"));
     return gate;
   }
 
@@ -400,7 +400,7 @@ public class ItemFactory {
             .addComponent(new TextureRenderComponent("images/placeable/sprinkler/pipe_null.png"))
             .addComponent(new ItemComponent("Sprinkler", ItemType.PLACEABLE,
                     "Waters crops in the surrounding area",
-                    new Texture("images/placeable/sprinkler/pipe_null.png")));
+                    "images/placeable/sprinkler/pipe_null.png"));
     return sprinkler;
   }
 
@@ -413,7 +413,7 @@ public class ItemFactory {
             .addComponent(new TextureRenderComponent("images/placeable/sprinkler/pump.png"))
             .addComponent(new ItemComponent("Pump", ItemType.PLACEABLE,
                     "Powers connected sprinklers",
-                    new Texture("images/placeable/sprinkler/pump.png")));
+                    "images/placeable/sprinkler/pump.png"));
     return pump;
   }
 
@@ -426,7 +426,7 @@ public class ItemFactory {
             .addComponent(new TextureRenderComponent("images/Temp-Chest.png"))
             .addComponent(new ItemComponent("Chest", ItemType.PLACEABLE,
                     "A storage container to keep your seeds and goodies",
-                    new Texture("images/Temp-Chest.png")));
+                    "images/Temp-Chest.png"));
     return chest;
   }
 
@@ -435,7 +435,7 @@ public class ItemFactory {
             .addComponent(new TextureRenderComponent("images/plants/misc/aloe_vera_seed.png"))
             .addComponent(new ItemComponent("Light", ItemType.PLACEABLE,
                     "A quick and easy fix to being scared of the dark!",
-                    new Texture("images/plants/misc/aloe_vera_seed.png")));
+                    "images/plants/misc/aloe_vera_seed.png"));
     return light;
   }
 
@@ -449,7 +449,7 @@ public class ItemFactory {
             .addComponent(new ItemComponent("Ship Part", ItemType.SHIP_PART,
                     "Pieces of scrap metal in surprisingly good condition. Seems like it could be used" +
                             " for ship repairs...",
-                    new Texture("images/ship/ship_part.png")));
+                    "images/ship/ship_part.png"));
     return shipPart;
   }
 }

--- a/source/core/src/main/com/csse3200/game/services/HealthDisplay.java
+++ b/source/core/src/main/com/csse3200/game/services/HealthDisplay.java
@@ -52,7 +52,7 @@ public class HealthDisplay extends UIComponent{
      */
     public void createTexture() {
         logger.debug("Health display texture being created");
-        Skin healthSkin = new Skin(Gdx.files.internal("flat-earth/skin/flat-earth-ui.json"));
+        Skin healthSkin = ServiceLocator.getResourceService().getAsset("flat-earth/skin/flat-earth-ui.json", Skin.class);
 
         healthOutline = new Image(ServiceLocator.getResourceService().getAsset(
             "images/bars_ui/bar_outline.png", Texture.class));

--- a/source/core/src/main/com/csse3200/game/services/HungerBar.java
+++ b/source/core/src/main/com/csse3200/game/services/HungerBar.java
@@ -12,105 +12,106 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.utils.Array;
 import com.csse3200.game.ui.UIComponent;
 
-public class HungerBar extends UIComponent{
-    Table table1 = new Table();
-    Group group1 = new Group();
-    private Image hungerBarOutline;
-    private Image hungerBarFill;
-    private Array<Label> hungerLabels;
-    private Label hungerLabel;
+public class HungerBar extends UIComponent {
+	Table table1 = new Table();
+	Group group1 = new Group();
+	private Image hungerBarOutline;
+	private Image hungerBarFill;
+	private Array<Label> hungerLabels;
+	private Label hungerLabel;
 
-    /**
-     * Creates reusable ui styles and adds actors to the stage.
-     */
-    @Override
-    public void create() {
-        super.create();
+	/**
+	 * Creates reusable ui styles and adds actors to the stage.
+	 */
+	@Override
+	public void create() {
+		super.create();
 
-        // Adds a listener to check for hunger updates
-        ServiceLocator.getPlayerHungerService().getEvents()
-                .addListener("hungerUpdate", this::updateDisplay);
+		// Adds a listener to check for hunger updates
+		ServiceLocator.getPlayerHungerService().getEvents()
+				.addListener("hungerUpdate", this::updateDisplay);
 
-        updateDisplay(30);
-    }
+		updateDisplay(30);
+	}
 
-    /**
-     * Initialises all the possible images and labels that will be used by
-     * the class, and stores them in an array to be called when needed.
-     */
-    public void createTexture() {
-        Skin hungerSkin = new Skin(Gdx.files.internal("flat-earth/skin/flat-earth-ui.json"));
+	/**
+	 * Initialises all the possible images and labels that will be used by
+	 * the class, and stores them in an array to be called when needed.
+	 */
+	public void createTexture() {
+		Skin hungerSkin = ServiceLocator.getResourceService().getAsset("flat-earth/skin/flat-earth-ui.json", Skin.class);
 
-        hungerBarOutline = new Image(ServiceLocator.getResourceService().getAsset(
-                "images/bars_ui/bar_outline.png", Texture.class));
-        hungerBarFill = new Image(ServiceLocator.getResourceService().getAsset(
-                "images/bars_ui/healthy_fill.png", Texture.class));
+		hungerBarOutline = new Image(ServiceLocator.getResourceService().getAsset(
+				"images/bars_ui/bar_outline.png", Texture.class));
+		hungerBarFill = new Image(ServiceLocator.getResourceService().getAsset(
+				"images/bars_ui/healthy_fill.png", Texture.class));
 
 
-        hungerLabels = new Array<>();
-        for (int i = 0; i <= 100; i++) {
-                Label label = new Label(String.format("Hunger: %d%%", i), hungerSkin);
-                Label.LabelStyle labelStyle = label.getStyle();
-                labelStyle.fontColor = Color.WHITE; // Set the text color to red (you can choose any color)
-                label.setStyle(labelStyle);
-                hungerLabels.add(label);
-        }
-    }
+		hungerLabels = new Array<>();
+		for (int i = 0; i <= 100; i++) {
+			Label label = new Label(String.format("Hunger: %d%%", i), hungerSkin);
+			Label.LabelStyle labelStyle = label.getStyle();
+			labelStyle.fontColor = Color.WHITE; // Set the text color to red (you can choose any color)
+			label.setStyle(labelStyle);
+			hungerLabels.add(label);
+		}
+	}
 
-    /**
-     * Updates the display, showing the hunger bar in the top of the main game screen.
-     */
-    public void updateDisplay(int hungerLevel) {
-        if (hungerLabels == null) {
-            createTexture();
-        }
+	/**
+	 * Updates the display, showing the hunger bar in the top of the main game screen.
+	 */
+	public void updateDisplay(int hungerLevel) {
+		if (hungerLabels == null) {
+			createTexture();
+		}
 
-        float scaling = (float) hungerLevel / 100;
+		float scaling = (float) hungerLevel / 100;
 
-        // Accounts for scaling of the hunger bar due to the hunger percent
-        hungerBarFill.setX(hungerBarFill.getImageX() + 14 * (1 - scaling));
-        hungerBarFill.setScaleX(scaling);
+		// Accounts for scaling of the hunger bar due to the hunger percent
+		hungerBarFill.setX(hungerBarFill.getImageX() + 14 * (1 - scaling));
+		hungerBarFill.setScaleX(scaling);
 
 //        hungerBarOutline.setPosition(-550f, -5f);
 
-        // Add a safety check to ensure that the array is always accessed at a possible index
-        if (0 <= hungerLevel && hungerLevel <= 100) {
-            hungerLabel = hungerLabels.get(hungerLevel);
-            hungerLabel.setPosition(hungerBarOutline.getImageX() + 125f, hungerBarOutline.getImageY() + 8.5f);
-        }
+		// Add a safety check to ensure that the array is always accessed at a possible index
+		if (0 <= hungerLevel && hungerLevel <= 100) {
+			hungerLabel = hungerLabels.get(hungerLevel);
+			hungerLabel.setPosition(hungerBarOutline.getImageX() + 125f, hungerBarOutline.getImageY() + 8.5f);
+		}
 
-    }
+	}
 
-    /**
-     * Draws the table and group onto the main game screen. Adds the hunger elements onto the stage.
-     * @param batch Batch to render to.
-     */
-    @Override
-    public void draw(SpriteBatch batch) {
-        table1.clear();
-        group1.clear();
-        table1.top();
-        table1.setFillParent(true);
+	/**
+	 * Draws the table and group onto the main game screen. Adds the hunger elements onto the stage.
+	 *
+	 * @param batch Batch to render to.
+	 */
+	@Override
+	public void draw(SpriteBatch batch) {
+		table1.clear();
+		group1.clear();
+		table1.top();
+		table1.setFillParent(true);
 
-        table1.padTop(-130f).padLeft(-1000f);
+		table1.padTop(-130f).padLeft(-1000f);
 
 
-        group1.addActor(hungerBarOutline);
-        group1.addActor(hungerBarFill);
-        group1.addActor(hungerLabel);
+		group1.addActor(hungerBarOutline);
+		group1.addActor(hungerBarFill);
+		group1.addActor(hungerLabel);
 
-        table1.add(group1).size(200);
-        stage.addActor(table1);
-    }
+		table1.add(group1).size(200);
+		stage.addActor(table1);
+	}
 
-    /**
-     * Removes all entities from the screen. Releases all resources from this class.
-     */
-    @Override
-    public void dispose() {
-        super.dispose();
-        hungerBarOutline.remove();
-        hungerBarFill.remove();
-        hungerLabel.remove();
-    }
+	/**
+	 * Removes all entities from the screen. Releases all resources from this class.
+	 */
+	@Override
+	public void dispose() {
+		super.dispose();
+		hungerBarOutline.remove();
+		hungerBarFill.remove();
+		hungerLabel.remove();
+	}
 }

--- a/source/core/src/main/com/csse3200/game/services/OxygenDisplay.java
+++ b/source/core/src/main/com/csse3200/game/services/OxygenDisplay.java
@@ -19,133 +19,134 @@ import org.slf4j.LoggerFactory;
 /**
  * A UI component for displaying the current oxygen level on the Main Game Screen.
  */
-public class OxygenDisplay extends UIComponent{
-    
-    private static final Logger logger = LoggerFactory.getLogger(OxygenDisplay.class);
-    Table table = new Table();
-    Group group = new Group();
-    private Image oxygenOutline;
-    private Image oxygenFill;
-    private Image oxygenHealthy;
-    private Image oxygenDanger;
-    private Array<Label> oxygenLabels;
-    private Label oxygenLabel;
+public class OxygenDisplay extends UIComponent {
 
-    /**
-     * Creates reusable ui styles and adds actors to the stage.
-     */
-    @Override
-    public void create() {
-        super.create();
-    
-        logger.debug("Adding listener to oxygenUpdate event");
-        // Adds a listener to check for oxygen updates
-        ServiceLocator.getPlanetOxygenService().getEvents()
-                .addListener("oxygenUpdate", this::updateDisplay);
+	private static final Logger logger = LoggerFactory.getLogger(OxygenDisplay.class);
+	Table table = new Table();
+	Group group = new Group();
+	private Image oxygenOutline;
+	private Image oxygenFill;
+	private Image oxygenHealthy;
+	private Image oxygenDanger;
+	private Array<Label> oxygenLabels;
+	private Label oxygenLabel;
 
-        // Initial update
-        updateDisplay();
-    }
+	/**
+	 * Creates reusable ui styles and adds actors to the stage.
+	 */
+	@Override
+	public void create() {
+		super.create();
 
-    /**
-     * Initialises all the possible images and labels that will be used by
-     * the class, and stores them in an array.
-     */
-    public void createTexture() {
-        logger.debug("Oxygen display texture being created");
-        Skin oxygenSkin = new Skin(Gdx.files.internal("flat-earth/skin/flat-earth-ui.json"));
+		logger.debug("Adding listener to oxygenUpdate event");
+		// Adds a listener to check for oxygen updates
+		ServiceLocator.getPlanetOxygenService().getEvents()
+				.addListener("oxygenUpdate", this::updateDisplay);
 
-        oxygenOutline = new Image(ServiceLocator.getResourceService().getAsset(
-            "images/bars_ui/bar_outline.png", Texture.class));
-        oxygenHealthy = new Image(ServiceLocator.getResourceService().getAsset(
-            "images/bars_ui/healthy_fill.png", Texture.class));
-        oxygenDanger = new Image(ServiceLocator.getResourceService().getAsset(
-            "images/bars_ui/danger_fill.png", Texture.class));
+		// Initial update
+		updateDisplay();
+	}
 
-        // Set oxygenFill to the initial starting one (VERY IMPORTANT)
-        oxygenFill = oxygenDanger;
-        oxygenFill.setScaleX(0.1f);
+	/**
+	 * Initialises all the possible images and labels that will be used by
+	 * the class, and stores them in an array.
+	 */
+	public void createTexture() {
+		logger.debug("Oxygen display texture being created");
+		Skin oxygenSkin = ServiceLocator.getResourceService().getAsset("flat-earth/skin/flat-earth-ui.json", Skin.class);
 
-        // Create labels for each percent
-        oxygenLabels = new Array<>();
-        for (int i = 0; i <= 100; i++) {
+		oxygenOutline = new Image(ServiceLocator.getResourceService().getAsset(
+				"images/bars_ui/bar_outline.png", Texture.class));
+		oxygenHealthy = new Image(ServiceLocator.getResourceService().getAsset(
+				"images/bars_ui/healthy_fill.png", Texture.class));
+		oxygenDanger = new Image(ServiceLocator.getResourceService().getAsset(
+				"images/bars_ui/danger_fill.png", Texture.class));
+
+		// Set oxygenFill to the initial starting one (VERY IMPORTANT)
+		oxygenFill = oxygenDanger;
+		oxygenFill.setScaleX(0.1f);
+
+		// Create labels for each percent
+		oxygenLabels = new Array<>();
+		for (int i = 0; i <= 100; i++) {
 //            oxygenLabels.add(new Label(String.format("Oxygen: %d%%", i), oxygenSkin));
-            Label label = new Label(String.format("Oxygen: %d%%", i), oxygenSkin);
-            Label.LabelStyle labelStyle = label.getStyle();
-            labelStyle.fontColor = Color.WHITE; // Set the text color to red (you can choose any color)
-            label.setStyle(labelStyle);
-            oxygenLabels.add(label);
-        }
-    }
+			Label label = new Label(String.format("Oxygen: %d%%", i), oxygenSkin);
+			Label.LabelStyle labelStyle = label.getStyle();
+			labelStyle.fontColor = Color.WHITE; // Set the text color to red (you can choose any color)
+			label.setStyle(labelStyle);
+			oxygenLabels.add(label);
+		}
+	}
 
-    /**
-     * Updates the display, showing the oxygen bar in the top of the main game screen.
-     */
-    public void updateDisplay() {
-        boolean switched;
-        if (oxygenLabels == null) {
-            createTexture();
-        }
+	/**
+	 * Updates the display, showing the oxygen bar in the top of the main game screen.
+	 */
+	public void updateDisplay() {
+		boolean switched;
+		if (oxygenLabels == null) {
+			createTexture();
+		}
 
-        int newOxygenPercent = ServiceLocator.getPlanetOxygenService().getOxygenPercentage();
-        float scaling = (float) newOxygenPercent / 100;
+		int newOxygenPercent = ServiceLocator.getPlanetOxygenService().getOxygenPercentage();
+		float scaling = (float) newOxygenPercent / 100;
 
-        // Adjusts the oxygen bar based on the oxygen percent
-        if (newOxygenPercent <= 25) {
-            switched = (oxygenFill != oxygenDanger);
-            oxygenFill = oxygenDanger;
-        } else {
-            switched = (oxygenFill != oxygenHealthy);
-            oxygenFill = oxygenHealthy;
-        }
+		// Adjusts the oxygen bar based on the oxygen percent
+		if (newOxygenPercent <= 25) {
+			switched = (oxygenFill != oxygenDanger);
+			oxygenFill = oxygenDanger;
+		} else {
+			switched = (oxygenFill != oxygenHealthy);
+			oxygenFill = oxygenHealthy;
+		}
 
-        oxygenFill.setX(oxygenFill.getImageX() + 14 * (1 - scaling));
+		oxygenFill.setX(oxygenFill.getImageX() + 14 * (1 - scaling));
 
-        // Ensure that the array is always accessed within bounds
-        if (0 <= newOxygenPercent && newOxygenPercent <= 100) {
-            logger.debug("Oxygen display updated");
-            oxygenLabel = oxygenLabels.get(newOxygenPercent);
-            oxygenLabel.setPosition(oxygenOutline.getImageX() + 125f, oxygenOutline.getImageY() + 8.5f);
-        }
+		// Ensure that the array is always accessed within bounds
+		if (0 <= newOxygenPercent && newOxygenPercent <= 100) {
+			logger.debug("Oxygen display updated");
+			oxygenLabel = oxygenLabels.get(newOxygenPercent);
+			oxygenLabel.setPosition(oxygenOutline.getImageX() + 125f, oxygenOutline.getImageY() + 8.5f);
+		}
 
-        if (!switched) {
-            oxygenFill.addAction(Actions.scaleTo(scaling, 1.0f, 1.0f, Interpolation.pow2InInverse));
-        } else {
-            oxygenFill.setScaleX(scaling);
-        }
-    }
+		if (!switched) {
+			oxygenFill.addAction(Actions.scaleTo(scaling, 1.0f, 1.0f, Interpolation.pow2InInverse));
+		} else {
+			oxygenFill.setScaleX(scaling);
+		}
+	}
 
-    /**
-     * Draws the table and group onto the main game screen. Adds the oxygen elements onto the stage.
-     * @param batch Batch to render to.
-     */
-    @Override
-    public void draw(SpriteBatch batch) {
-        table.clear();
-        group.clear();
-        table.top();
-        table.setFillParent(true);
+	/**
+	 * Draws the table and group onto the main game screen. Adds the oxygen elements onto the stage.
+	 *
+	 * @param batch Batch to render to.
+	 */
+	@Override
+	public void draw(SpriteBatch batch) {
+		table.clear();
+		group.clear();
+		table.top();
+		table.setFillParent(true);
 
-        table.padTop(-130f).padLeft(-180f);
+		table.padTop(-130f).padLeft(-180f);
 
 
-        group.addActor(oxygenOutline);
-        group.addActor(oxygenFill);
-        group.addActor(oxygenLabel);
+		group.addActor(oxygenOutline);
+		group.addActor(oxygenFill);
+		group.addActor(oxygenLabel);
 
-        table.add(group).size(200);
-        stage.addActor(table);
-    }
+		table.add(group).size(200);
+		stage.addActor(table);
+	}
 
-    /**
-     * Removes all entities from the screen and releases all resources from this class.
-     */
-    @Override
-    public void dispose() {
-        super.dispose();
-        oxygenOutline.remove();
-        oxygenFill.remove();
-        oxygenHealthy.remove();
-        oxygenLabel.remove();
-    }
+	/**
+	 * Removes all entities from the screen and releases all resources from this class.
+	 */
+	@Override
+	public void dispose() {
+		super.dispose();
+		oxygenOutline.remove();
+		oxygenFill.remove();
+		oxygenHealthy.remove();
+		oxygenLabel.remove();
+	}
 }

--- a/source/core/src/main/com/csse3200/game/services/ResourceService.java
+++ b/source/core/src/main/com/csse3200/game/services/ResourceService.java
@@ -1,6 +1,7 @@
 package com.csse3200.game.services;
 
 import com.badlogic.gdx.graphics.g2d.ParticleEffect;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -178,6 +179,10 @@ public class ResourceService implements Disposable {
    */
   public void loadParticleEffects(String[] particleNames) {
     loadAssets(particleNames, ParticleEffect.class);
+  }
+
+  public void loadSkins(String[] skinNames) {
+    loadAssets(skinNames, Skin.class);
   }
 
   /**

--- a/source/core/src/test/com/csse3200/game/components/inventory/TestInventoryManager.java
+++ b/source/core/src/test/com/csse3200/game/components/inventory/TestInventoryManager.java
@@ -7,6 +7,7 @@ import com.csse3200.game.entities.Entity;
 import com.csse3200.game.extensions.GameExtension;
 import com.csse3200.game.input.InputService;
 import com.csse3200.game.rendering.RenderService;
+import com.csse3200.game.services.ResourceService;
 import com.csse3200.game.services.ServiceLocator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,11 +27,18 @@ public class TestInventoryManager {
     InventoryDisplayManager displayManager;
     Stage stage;
 
+    static String[] skinPaths = {
+            "gardens-of-the-galaxy/gardens-of-the-galaxy.json"
+    };
+
     /**
      * Create a player entity.
      */
     @BeforeEach
     void createConditions() {
+        ServiceLocator.registerResourceService(new ResourceService());
+        ServiceLocator.getResourceService().loadSkins(skinPaths);
+        ServiceLocator.getResourceService().loadAll();
         stage = mock(Stage.class);
 
         RenderService renderService = new RenderService();

--- a/source/core/src/test/com/csse3200/game/components/inventory/TestInventoryUI.java
+++ b/source/core/src/test/com/csse3200/game/components/inventory/TestInventoryUI.java
@@ -126,11 +126,10 @@ public class TestInventoryUI {
 
     private static Stream<Arguments> addingItemsShouldAddInventoryImagesParams() {
         return Stream.of(
-                arguments(new ItemComponent("Hoe", ItemType.HOE, new Texture(Gdx.files.internal("images/tool_hoe.png"))),0),
-                arguments(new ItemComponent("Scythe", ItemType.SCYTHE, new Texture(Gdx.files.internal("images/tool_scythe.png"))),1),
-                arguments(new ItemComponent("Shovel", ItemType.SHOVEL, new Texture(Gdx.files.internal("images/tool_shovel.png"))),2),
-                arguments(new ItemComponent("Item", ItemType.FERTILISER, new Texture(Gdx.files.internal("images/tool_shovel.png"))),3)
-
+                arguments(new ItemComponent("Hoe", ItemType.HOE, "images/tool_hoe.png"),0),
+                arguments(new ItemComponent("Scythe", ItemType.SCYTHE, "images/tool_scythe.png"),1),
+                arguments(new ItemComponent("Shovel", ItemType.SHOVEL, "images/tool_shovel.png"),2),
+                arguments(new ItemComponent("Item", ItemType.FERTILISER, "images/tool_shovel.png"),3)
         );
     }
 

--- a/source/core/src/test/com/csse3200/game/components/inventory/TestInventoryUI.java
+++ b/source/core/src/test/com/csse3200/game/components/inventory/TestInventoryUI.java
@@ -48,7 +48,13 @@ public class TestInventoryUI {
 	InventoryDisplayManager inventoryDisplayManager;
 	ArgumentCaptor<Window> windowArgument;
 
-	static String[] texturePaths = {"images/tool_shovel.png", "images/tool_hoe.png", "images/tool_scythe.png"};
+	static String[] texturePaths = {
+			"images/tool_shovel.png",
+			"images/tool_hoe.png",
+			"images/tool_scythe.png",
+			"images/selected.png",
+			"images/itemFrame.png"
+	};
 
 	@BeforeAll
 	static void Create() {
@@ -60,6 +66,9 @@ public class TestInventoryUI {
 	 */
 	@BeforeEach
 	void createPlayer() {
+		ServiceLocator.registerResourceService(new ResourceService());
+		ServiceLocator.getResourceService().loadTextures(texturePaths);
+		ServiceLocator.getResourceService().loadAll();
 
 		windowArgument = ArgumentCaptor.forClass(Window.class);
 		stage = mock(Stage.class);
@@ -81,7 +90,6 @@ public class TestInventoryUI {
 
 	@Test
 	void testToggleInventory() {
-
 		player.create();
 		verify(inventoryDisplay).create();
 		verify(stage).addActor(windowArgument.capture());

--- a/source/core/src/test/com/csse3200/game/components/inventory/TestInventoryUI.java
+++ b/source/core/src/test/com/csse3200/game/components/inventory/TestInventoryUI.java
@@ -60,9 +60,6 @@ public class TestInventoryUI {
 	 */
 	@BeforeEach
 	void createPlayer() {
-		ServiceLocator.registerResourceService(new ResourceService());
-		ServiceLocator.getResourceService().loadTextures(texturePaths);
-		ServiceLocator.getResourceService().loadAll();
 
 		windowArgument = ArgumentCaptor.forClass(Window.class);
 		stage = mock(Stage.class);
@@ -136,6 +133,9 @@ public class TestInventoryUI {
 	}
 
 	private static Stream<Arguments> addingItemsShouldAddInventoryImagesParams() {
+		ServiceLocator.registerResourceService(new ResourceService());
+		ServiceLocator.getResourceService().loadTextures(texturePaths);
+		ServiceLocator.getResourceService().loadAll();
 		return Stream.of(
 				arguments(new ItemComponent("Hoe", ItemType.HOE, "images/tool_hoe.png"), 0),
 				arguments(new ItemComponent("Scythe", ItemType.SCYTHE, "images/tool_scythe.png"), 1),

--- a/source/core/src/test/com/csse3200/game/components/inventory/TestInventoryUI.java
+++ b/source/core/src/test/com/csse3200/game/components/inventory/TestInventoryUI.java
@@ -56,6 +56,10 @@ public class TestInventoryUI {
 			"images/itemFrame.png"
 	};
 
+	static String[] skinPaths = {
+			"gardens-of-the-galaxy/gardens-of-the-galaxy.json"
+	};
+
 	@BeforeAll
 	static void Create() {
 		inventory = new InventoryComponent(new ArrayList<>());
@@ -68,6 +72,7 @@ public class TestInventoryUI {
 	void createPlayer() {
 		ServiceLocator.registerResourceService(new ResourceService());
 		ServiceLocator.getResourceService().loadTextures(texturePaths);
+		ServiceLocator.getResourceService().loadSkins(skinPaths);
 		ServiceLocator.getResourceService().loadAll();
 
 		windowArgument = ArgumentCaptor.forClass(Window.class);
@@ -114,6 +119,7 @@ public class TestInventoryUI {
 	void addingItemsShouldAddInventoryImages(ItemComponent component, int expected) {
 		ServiceLocator.registerResourceService(new ResourceService());
 		ServiceLocator.getResourceService().loadTextures(texturePaths);
+		ServiceLocator.getResourceService().loadSkins(skinPaths);
 		ServiceLocator.getResourceService().loadAll();
 
 		player.create();

--- a/source/core/src/test/com/csse3200/game/components/inventory/TestToolbarUI.java
+++ b/source/core/src/test/com/csse3200/game/components/inventory/TestToolbarUI.java
@@ -35,6 +35,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 
+import javax.swing.*;
+
 /**
  * Factory to create a mock player entity for testing.
  * Only includes necessary components for testing.
@@ -49,12 +51,16 @@ public class TestToolbarUI {
 	static InventoryComponent inventory;
 	ArgumentCaptor<Window> windowArgument;
 	Stage stage;
-	String[] texturePaths = {
+	static String[] texturePaths = {
 			"images/tool_shovel.png",
 			"images/tool_hoe.png",
 			"images/tool_scythe.png",
 			"images/selected.png",
 			"images/itemFrame.png"
+	};
+
+	static String[] skinPaths = {
+			"gardens-of-the-galaxy/gardens-of-the-galaxy.json"
 	};
 
 
@@ -68,6 +74,10 @@ public class TestToolbarUI {
 	 */
 	@BeforeEach
 	void createPlayer() {
+		ServiceLocator.registerResourceService(new ResourceService());
+		ServiceLocator.getResourceService().loadTextures(texturePaths);
+		ServiceLocator.getResourceService().loadSkins(skinPaths);
+		ServiceLocator.getResourceService().loadAll();
 
 		stage = mock(Stage.class);
 		windowArgument = ArgumentCaptor.forClass(Window.class);
@@ -90,9 +100,6 @@ public class TestToolbarUI {
 
 	@Test
 	void testToggleToolbar() {
-		ServiceLocator.registerResourceService(new ResourceService());
-		ServiceLocator.getResourceService().loadTextures(texturePaths);
-		ServiceLocator.getResourceService().loadAll();
 		player.create();
 		verify(toolbarDisplay).create();
 		verify(stage).addActor(windowArgument.capture());
@@ -113,7 +120,8 @@ public class TestToolbarUI {
 	@MethodSource({"addingItemsShouldAddInventoryImagesParams"})
 	void addingItemsShouldAddInventoryImages(ItemComponent component, int expected) {
 		ServiceLocator.registerResourceService(new ResourceService());
-		ServiceLocator.getResourceService().loadTextures(new String[]{"images/tool_hoe.png", "images/tool_shovel.png", "images/tool_scythe.png", "images/selected.png", "images/itemFrame.png"});
+		ServiceLocator.getResourceService().loadTextures(texturePaths);
+		ServiceLocator.getResourceService().loadSkins(skinPaths);
 		ServiceLocator.getResourceService().loadAll();
 		player.create();
 		ArgumentCaptor<Window> win = ArgumentCaptor.forClass(Window.class);
@@ -141,7 +149,7 @@ public class TestToolbarUI {
 
 	private static Stream<Arguments> addingItemsShouldAddInventoryImagesParams() {
 		ServiceLocator.registerResourceService(new ResourceService());
-		ServiceLocator.getResourceService().loadTextures(new String[]{"images/tool_hoe.png", "images/tool_shovel.png", "images/tool_scythe.png"});
+		ServiceLocator.getResourceService().loadTextures(texturePaths);
 		ServiceLocator.getResourceService().loadAll();
 		return Stream.of(
 				arguments(new ItemComponent("Hoe", ItemType.HOE, "images/tool_hoe.png"), 0),

--- a/source/core/src/test/com/csse3200/game/components/inventory/TestToolbarUI.java
+++ b/source/core/src/test/com/csse3200/game/components/inventory/TestToolbarUI.java
@@ -14,6 +14,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.*;
 import com.csse3200.game.components.items.ItemComponent;
 import com.csse3200.game.components.items.ItemType;
 import com.csse3200.game.entities.EntityType;
+import com.csse3200.game.services.ResourceService;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,7 @@ public class TestToolbarUI {
     static InventoryComponent inventory;
     ArgumentCaptor<Window> windowArgument;
     Stage stage;
+    String[] texturePaths = {"images/tool_shovel.png", "images/tool_hoe.png", "images/tool_scythe.png"};
 
 
     @BeforeAll
@@ -59,6 +61,7 @@ public class TestToolbarUI {
      */
     @BeforeEach
     void createPlayer() {
+
         stage = mock(Stage.class);
         windowArgument = ArgumentCaptor.forClass(Window.class);
         RenderService renderService = new RenderService();
@@ -68,6 +71,10 @@ public class TestToolbarUI {
         ServiceLocator.registerInputService(new InputService());
         inventory = new InventoryComponent(new ArrayList<>());
         toolbarDisplay = spy(new ToolbarDisplay());
+
+        ServiceLocator.registerResourceService(new ResourceService());
+        ServiceLocator.getResourceService().loadTextures(texturePaths);
+        ServiceLocator.getResourceService().loadAll();
 
         player =
                 new Entity()

--- a/source/core/src/test/com/csse3200/game/components/inventory/TestToolbarUI.java
+++ b/source/core/src/test/com/csse3200/game/components/inventory/TestToolbarUI.java
@@ -44,106 +44,106 @@ import org.mockito.ArgumentCaptor;
  */
 @ExtendWith(GameExtension.class)
 public class TestToolbarUI {
-    Entity player;
-    ToolbarDisplay toolbarDisplay;
-    static InventoryComponent inventory;
-    ArgumentCaptor<Window> windowArgument;
-    Stage stage;
-    String[] texturePaths = {"images/tool_shovel.png", "images/tool_hoe.png", "images/tool_scythe.png"};
+	Entity player;
+	ToolbarDisplay toolbarDisplay;
+	static InventoryComponent inventory;
+	ArgumentCaptor<Window> windowArgument;
+	Stage stage;
+	String[] texturePaths = {"images/tool_shovel.png", "images/tool_hoe.png", "images/tool_scythe.png"};
 
 
-    @BeforeAll
-    static void Create() {
-         inventory = new InventoryComponent(new ArrayList<>());
-    }
-    /**
-     * Create a player with an inventory.
-     */
-    @BeforeEach
-    void createPlayer() {
+	@BeforeAll
+	static void Create() {
+		inventory = new InventoryComponent(new ArrayList<>());
+	}
 
-        stage = mock(Stage.class);
-        windowArgument = ArgumentCaptor.forClass(Window.class);
-        RenderService renderService = new RenderService();
-        renderService.setStage(stage);
+	/**
+	 * Create a player with an inventory.
+	 */
+	@BeforeEach
+	void createPlayer() {
 
-        ServiceLocator.registerRenderService(renderService);
-        ServiceLocator.registerInputService(new InputService());
-        inventory = new InventoryComponent(new ArrayList<>());
-        toolbarDisplay = spy(new ToolbarDisplay());
+		stage = mock(Stage.class);
+		windowArgument = ArgumentCaptor.forClass(Window.class);
+		RenderService renderService = new RenderService();
+		renderService.setStage(stage);
 
-        ServiceLocator.registerResourceService(new ResourceService());
-        ServiceLocator.getResourceService().loadTextures(texturePaths);
-        ServiceLocator.getResourceService().loadAll();
+		ServiceLocator.registerRenderService(renderService);
+		ServiceLocator.registerInputService(new InputService());
+		inventory = new InventoryComponent(new ArrayList<>());
+		toolbarDisplay = spy(new ToolbarDisplay());
 
-        player =
-                new Entity()
-                        .addComponent(new PlayerActions())
-                        .addComponent(new KeyboardPlayerInputComponent())
-                        .addComponent(toolbarDisplay)
-                        .addComponent(inventory);
-    }
-    @Test
-    void testToggleToolbar() {
-        player.create();
-        verify(toolbarDisplay).create();
-        verify(stage).addActor(windowArgument.capture());
-        Window window = windowArgument.getValue();
 
-        Table inventorySlots = (Table) window.getChildren().begin()[1];
-        for (Cell<?> cell : inventorySlots.getCells().toArray(Cell.class))
-        {
-            assert !(cell.getActor() instanceof ItemSlot) || ((ItemSlot) cell.getActor()).getItemImage() == null;
-        }
+		player =
+				new Entity()
+						.addComponent(new PlayerActions())
+						.addComponent(new KeyboardPlayerInputComponent())
+						.addComponent(toolbarDisplay)
+						.addComponent(inventory);
+	}
 
-        player.getComponent(KeyboardPlayerInputComponent.class).setActions(player.getComponent(PlayerActions.class));
-        player.getComponent(KeyboardPlayerInputComponent.class).keyDown(Input.Keys.I);
-       //verify(toolbarDisplay).updateInventory();
-        verify(toolbarDisplay).toggleOpen();
-    }
-    @ParameterizedTest
-    @MethodSource({"addingItemsShouldAddInventoryImagesParams"})
-    void addingItemsShouldAddInventoryImages(ItemComponent component, int expected) {
-        player.create();
-        ArgumentCaptor<Window> win = ArgumentCaptor.forClass(Window.class);
-        verify(stage).addActor(windowArgument.capture());
-        verify(stage).addActor(win.capture());
-        Entity i1 = new Entity(EntityType.ITEM).addComponent(component);
-        inventory.addItem(i1);
-        toolbarDisplay.updateInventory();
-        toolbarDisplay.toggleOpen();
-        Window window = windowArgument.getValue();
-        Table inventorySlots = (Table) window.getChildren().begin()[1];
-        int i = 0;
-        for (Cell slot:inventorySlots.getCells().toArray(Cell.class) ) {
-            assert ((ItemSlot) slot.getActor()).getChild(0) instanceof Image;
-            assert ((ItemSlot) slot.getActor()).getChild(1) instanceof Stack;
-            assert ((ItemSlot) slot.getActor()).getChild(2) instanceof Label;
-            assert Integer.parseInt(((Label) ((ItemSlot) slot.getActor()).getChild(2)).getText().toString().trim()) == (i + 1) % 10;
-            if (i++ == 0) {
-                assert ((Stack) ((ItemSlot) slot.getActor()).getChild(1)).getChild(0) instanceof Image;
-            }
-            else {
-                assert ((Stack) ((ItemSlot) slot.getActor()).getChild(1)).getChildren().isEmpty() ;
-            }
-        }
-    }
+	@Test
+	void testToggleToolbar() {
+		player.create();
+		verify(toolbarDisplay).create();
+		verify(stage).addActor(windowArgument.capture());
+		Window window = windowArgument.getValue();
 
-    private static Stream<Arguments> addingItemsShouldAddInventoryImagesParams() {
-        return Stream.of(
-                arguments(new ItemComponent("Hoe", ItemType.HOE, "images/tool_hoe.png"),0),
-                arguments(new ItemComponent("Scythe", ItemType.SCYTHE, "images/tool_scythe.png"),1),
-                arguments(new ItemComponent("Shovel", ItemType.SHOVEL, "images/tool_shovel.png"),2),
-                arguments(new ItemComponent("Item", ItemType.FERTILISER, "images/tool_shovel.png"),3),
-                arguments(new ItemComponent("Hoe", ItemType.HOE, "images/tool_hoe.png"),4),
-                arguments(new ItemComponent("Scythe", ItemType.SCYTHE, "images/tool_scythe.png"),5),
-                arguments(new ItemComponent("Shovel", ItemType.SHOVEL, "images/tool_shovel.png"),6),
-                arguments(new ItemComponent("Item", ItemType.FERTILISER, "images/tool_shovel.png"),7),
-                arguments(new ItemComponent("Hoe", ItemType.HOE, "images/tool_hoe.png"),8),
-                arguments(new ItemComponent("Scythe", ItemType.SCYTHE, "images/tool_scythe.png"),9)
-        );
-    }
+		Table inventorySlots = (Table) window.getChildren().begin()[1];
+		for (Cell<?> cell : inventorySlots.getCells().toArray(Cell.class)) {
+			assert !(cell.getActor() instanceof ItemSlot) || ((ItemSlot) cell.getActor()).getItemImage() == null;
+		}
 
+		player.getComponent(KeyboardPlayerInputComponent.class).setActions(player.getComponent(PlayerActions.class));
+		player.getComponent(KeyboardPlayerInputComponent.class).keyDown(Input.Keys.I);
+		//verify(toolbarDisplay).updateInventory();
+		verify(toolbarDisplay).toggleOpen();
+	}
+
+	@ParameterizedTest
+	@MethodSource({"addingItemsShouldAddInventoryImagesParams"})
+	void addingItemsShouldAddInventoryImages(ItemComponent component, int expected) {
+		player.create();
+		ArgumentCaptor<Window> win = ArgumentCaptor.forClass(Window.class);
+		verify(stage).addActor(windowArgument.capture());
+		verify(stage).addActor(win.capture());
+		Entity i1 = new Entity(EntityType.ITEM).addComponent(component);
+		inventory.addItem(i1);
+		toolbarDisplay.updateInventory();
+		toolbarDisplay.toggleOpen();
+		Window window = windowArgument.getValue();
+		Table inventorySlots = (Table) window.getChildren().begin()[1];
+		int i = 0;
+		for (Cell slot : inventorySlots.getCells().toArray(Cell.class)) {
+			assert ((ItemSlot) slot.getActor()).getChild(0) instanceof Image;
+			assert ((ItemSlot) slot.getActor()).getChild(1) instanceof Stack;
+			assert ((ItemSlot) slot.getActor()).getChild(2) instanceof Label;
+			assert Integer.parseInt(((Label) ((ItemSlot) slot.getActor()).getChild(2)).getText().toString().trim()) == (i + 1) % 10;
+			if (i++ == 0) {
+				assert ((Stack) ((ItemSlot) slot.getActor()).getChild(1)).getChild(0) instanceof Image;
+			} else {
+				assert ((Stack) ((ItemSlot) slot.getActor()).getChild(1)).getChildren().isEmpty();
+			}
+		}
+	}
+
+	private static Stream<Arguments> addingItemsShouldAddInventoryImagesParams() {
+		ServiceLocator.registerResourceService(new ResourceService());
+		ServiceLocator.getResourceService().loadTextures(new String[]{"images/tool_hoe.png", "images/tool_shovel.png", "images/tool_scythe.png"});
+		ServiceLocator.getResourceService().loadAll();
+		return Stream.of(
+				arguments(new ItemComponent("Hoe", ItemType.HOE, "images/tool_hoe.png"), 0),
+				arguments(new ItemComponent("Scythe", ItemType.SCYTHE, "images/tool_scythe.png"), 1),
+				arguments(new ItemComponent("Shovel", ItemType.SHOVEL, "images/tool_shovel.png"), 2),
+				arguments(new ItemComponent("Item", ItemType.FERTILISER, "images/tool_shovel.png"), 3),
+				arguments(new ItemComponent("Hoe", ItemType.HOE, "images/tool_hoe.png"), 4),
+				arguments(new ItemComponent("Scythe", ItemType.SCYTHE, "images/tool_scythe.png"), 5),
+				arguments(new ItemComponent("Shovel", ItemType.SHOVEL, "images/tool_shovel.png"), 6),
+				arguments(new ItemComponent("Item", ItemType.FERTILISER, "images/tool_shovel.png"), 7),
+				arguments(new ItemComponent("Hoe", ItemType.HOE, "images/tool_hoe.png"), 8),
+				arguments(new ItemComponent("Scythe", ItemType.SCYTHE, "images/tool_scythe.png"), 9)
+		);
+	}
 
 
 }

--- a/source/core/src/test/com/csse3200/game/components/inventory/TestToolbarUI.java
+++ b/source/core/src/test/com/csse3200/game/components/inventory/TestToolbarUI.java
@@ -49,7 +49,13 @@ public class TestToolbarUI {
 	static InventoryComponent inventory;
 	ArgumentCaptor<Window> windowArgument;
 	Stage stage;
-	String[] texturePaths = {"images/tool_shovel.png", "images/tool_hoe.png", "images/tool_scythe.png"};
+	String[] texturePaths = {
+			"images/tool_shovel.png",
+			"images/tool_hoe.png",
+			"images/tool_scythe.png",
+			"images/selected.png",
+			"images/itemFrame.png"
+	};
 
 
 	@BeforeAll
@@ -84,6 +90,9 @@ public class TestToolbarUI {
 
 	@Test
 	void testToggleToolbar() {
+		ServiceLocator.registerResourceService(new ResourceService());
+		ServiceLocator.getResourceService().loadTextures(texturePaths);
+		ServiceLocator.getResourceService().loadAll();
 		player.create();
 		verify(toolbarDisplay).create();
 		verify(stage).addActor(windowArgument.capture());
@@ -103,6 +112,9 @@ public class TestToolbarUI {
 	@ParameterizedTest
 	@MethodSource({"addingItemsShouldAddInventoryImagesParams"})
 	void addingItemsShouldAddInventoryImages(ItemComponent component, int expected) {
+		ServiceLocator.registerResourceService(new ResourceService());
+		ServiceLocator.getResourceService().loadTextures(new String[]{"images/tool_hoe.png", "images/tool_shovel.png", "images/tool_scythe.png", "images/selected.png", "images/itemFrame.png"});
+		ServiceLocator.getResourceService().loadAll();
 		player.create();
 		ArgumentCaptor<Window> win = ArgumentCaptor.forClass(Window.class);
 		verify(stage).addActor(windowArgument.capture());

--- a/source/core/src/test/com/csse3200/game/components/inventory/TestToolbarUI.java
+++ b/source/core/src/test/com/csse3200/game/components/inventory/TestToolbarUI.java
@@ -124,17 +124,16 @@ public class TestToolbarUI {
 
     private static Stream<Arguments> addingItemsShouldAddInventoryImagesParams() {
         return Stream.of(
-                arguments(new ItemComponent("Hoe", ItemType.HOE, new Texture(Gdx.files.internal("images/tool_hoe.png"))),0),
-                arguments(new ItemComponent("Scythe", ItemType.SCYTHE, new Texture(Gdx.files.internal("images/tool_scythe.png"))),1),
-                arguments(new ItemComponent("Shovel", ItemType.SHOVEL, new Texture(Gdx.files.internal("images/tool_shovel.png"))),2),
-                arguments(new ItemComponent("Item", ItemType.FERTILISER, new Texture(Gdx.files.internal("images/tool_shovel.png"))),3),
-                arguments(new ItemComponent("Hoe", ItemType.HOE, new Texture(Gdx.files.internal("images/tool_hoe.png"))),4),
-                arguments(new ItemComponent("Scythe", ItemType.SCYTHE, new Texture(Gdx.files.internal("images/tool_scythe.png"))),5),
-                arguments(new ItemComponent("Shovel", ItemType.SHOVEL, new Texture(Gdx.files.internal("images/tool_shovel.png"))),6),
-                arguments(new ItemComponent("Item", ItemType.FERTILISER, new Texture(Gdx.files.internal("images/tool_shovel.png"))),7),
-                arguments(new ItemComponent("Hoe", ItemType.HOE, new Texture(Gdx.files.internal("images/tool_hoe.png"))),8),
-                arguments(new ItemComponent("Scythe", ItemType.SCYTHE, new Texture(Gdx.files.internal("images/tool_scythe.png"))),9)
-
+                arguments(new ItemComponent("Hoe", ItemType.HOE, "images/tool_hoe.png"),0),
+                arguments(new ItemComponent("Scythe", ItemType.SCYTHE, "images/tool_scythe.png"),1),
+                arguments(new ItemComponent("Shovel", ItemType.SHOVEL, "images/tool_shovel.png"),2),
+                arguments(new ItemComponent("Item", ItemType.FERTILISER, "images/tool_shovel.png"),3),
+                arguments(new ItemComponent("Hoe", ItemType.HOE, "images/tool_hoe.png"),4),
+                arguments(new ItemComponent("Scythe", ItemType.SCYTHE, "images/tool_scythe.png"),5),
+                arguments(new ItemComponent("Shovel", ItemType.SHOVEL, "images/tool_shovel.png"),6),
+                arguments(new ItemComponent("Item", ItemType.FERTILISER, "images/tool_shovel.png"),7),
+                arguments(new ItemComponent("Hoe", ItemType.HOE, "images/tool_hoe.png"),8),
+                arguments(new ItemComponent("Scythe", ItemType.SCYTHE, "images/tool_scythe.png"),9)
         );
     }
 

--- a/source/core/src/test/com/csse3200/game/components/items/ItemComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/items/ItemComponentTest.java
@@ -3,17 +3,31 @@ package com.csse3200.game.components.items;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import com.csse3200.game.services.ResourceService;
+import com.csse3200.game.services.ServiceLocator;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.badlogic.gdx.graphics.Texture;
 import com.csse3200.game.extensions.GameExtension;
 
+import java.io.Serial;
+
 @ExtendWith(GameExtension.class)
 class ItemComponentTest {
+
+  static String[] texturePaths = {"images/tool_shovel.png", "images/tool_hoe.png"};
+  @BeforeAll
+  static void setup() {
+    ServiceLocator.registerResourceService(new ResourceService());
+    ServiceLocator.getResourceService().loadTextures(texturePaths);
+
+  }
+
   @Test
   void createItemComponentConstructorBase() {
-    ItemComponent item = new ItemComponent("test", ItemType.SHOVEL, new Texture("images/tool_shovel.png"));
+    ItemComponent item = new ItemComponent("test", ItemType.SHOVEL, "images/tool_shovel.png");
     assertEquals("test", item.getItemName());
     assertEquals(0, item.getPrice());
     assertEquals("", item.getItemDescription());
@@ -24,21 +38,19 @@ class ItemComponentTest {
 
   @Test
   void createItemGetPrice() {
-    Texture texture = new Texture("images/tool_hoe.png");
-    ItemComponent item = new ItemComponent("hoe", ItemType.HOE, 3, texture);
+    ItemComponent item = new ItemComponent("hoe", ItemType.HOE, 3, "images/tool_hoe.png");
     assertEquals("hoe", item.getItemName());
     assertEquals(3, item.getPrice());
     assertEquals(true, item.isSellable());
     assertEquals(ItemType.HOE, item.getItemType());
-    assertEquals(texture, item.getItemTexture());
-    Texture texture2 = new Texture("images/tool_shovel.png");
-    item.setItemTexture(texture2);
-    assertEquals(texture2, item.getItemTexture());
+    assertEquals(ServiceLocator.getResourceService().getAsset("images/tool_hoe.png", Texture.class), item.getItemTexture());
+    item.setItemTexture("images/tool_shovel.png");
+    assertEquals(ServiceLocator.getResourceService().getAsset("images/tool_shovel.png", Texture.class), item.getItemTexture());
   }
 
   @Test
   void createItemComponentConstructorDescription() {
-    ItemComponent item = new ItemComponent("test", ItemType.HOE, "test description", new Texture("images/tool_shovel.png"));
+    ItemComponent item = new ItemComponent("test", ItemType.HOE, "test description", "images/tool_shovel.png");
     assertEquals("test", item.getItemName());
     assertEquals(0, item.getPrice());
     assertEquals("test description", item.getItemDescription());
@@ -48,7 +60,7 @@ class ItemComponentTest {
 
   @Test
   void createItemComponentConstructorDescriptionPrice() {
-    ItemComponent item = new ItemComponent("test", ItemType.SCYTHE, "test description", 10, new Texture("images/tool_shovel.png"));
+    ItemComponent item = new ItemComponent("test", ItemType.SCYTHE, "test description", 10, "images/tool_shovel.png");
     assertEquals("test", item.getItemName());
     assertEquals(10, item.getPrice());
     assertEquals("test description", item.getItemDescription());
@@ -58,29 +70,29 @@ class ItemComponentTest {
 
   @Test
   void setItemName() {
-    ItemComponent item = new ItemComponent("test", ItemType.WATERING_CAN, new Texture("images/tool_shovel.png"));
+    ItemComponent item = new ItemComponent("test", ItemType.WATERING_CAN, "images/tool_shovel.png");
     item.setItemName("test2");
     assertEquals("test2", item.getItemName());
   }
 
   @Test 
   void setPrice() {
-    ItemComponent item = new ItemComponent("test", ItemType.SCYTHE, new Texture("images/tool_shovel.png"));
+    ItemComponent item = new ItemComponent("test", ItemType.SCYTHE, "images/tool_shovel.png");
     item.setPrice(10);
     assertEquals(10, item.getPrice());
   }
 
   @Test 
   void setDescription() {
-    ItemComponent item = new ItemComponent("test", ItemType.HOE, new Texture("images/tool_shovel.png"));
+    ItemComponent item = new ItemComponent("test", ItemType.HOE, "images/tool_shovel.png");
     item.setItemDescription("test description");
     assertEquals("test description", item.getItemDescription());
   }
 
   @Test
   void idUnique() {
-    ItemComponent item = new ItemComponent("test", ItemType.HOE, new Texture("images/tool_shovel.png"));
-    ItemComponent item2 = new ItemComponent("test", ItemType.HOE, new Texture("images/tool_shovel.png"));
+    ItemComponent item = new ItemComponent("test", ItemType.HOE, "images/tool_shovel.png");
+    ItemComponent item2 = new ItemComponent("test", ItemType.HOE, "images/tool_shovel.png");
     assertNotEquals(item.getItemId(), item2.getItemId());
   }
 }

--- a/source/core/src/test/com/csse3200/game/components/items/ItemComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/items/ItemComponentTest.java
@@ -5,7 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import com.csse3200.game.services.ResourceService;
 import com.csse3200.game.services.ServiceLocator;
+import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -18,12 +21,18 @@ import java.io.Serial;
 class ItemComponentTest {
 
   static String[] texturePaths = {"images/tool_shovel.png", "images/tool_hoe.png"};
-  @BeforeAll
-  static void setup() {
+  @BeforeEach
+  void setup() {
     ServiceLocator.registerResourceService(new ResourceService());
     ServiceLocator.getResourceService().loadTextures(texturePaths);
-
+    ServiceLocator.getResourceService().loadAll();
   }
+
+  @AfterEach
+  void clear() {
+    ServiceLocator.clear();
+  }
+
 
   @Test
   void createItemComponentConstructorBase() {

--- a/source/core/src/test/com/csse3200/game/components/items/ItemComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/items/ItemComponentTest.java
@@ -20,11 +20,10 @@ import java.io.Serial;
 @ExtendWith(GameExtension.class)
 class ItemComponentTest {
 
-  static String[] texturePaths = {"images/tool_shovel.png", "images/tool_hoe.png"};
   @BeforeEach
   void setup() {
     ServiceLocator.registerResourceService(new ResourceService());
-    ServiceLocator.getResourceService().loadTextures(texturePaths);
+    ServiceLocator.getResourceService().loadTextures(new String[]{"images/tool_shovel.png", "images/tool_hoe.png"});
     ServiceLocator.getResourceService().loadAll();
   }
 

--- a/source/core/src/test/com/csse3200/game/components/npc/MultiDropComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/npc/MultiDropComponentTest.java
@@ -18,6 +18,7 @@ import com.csse3200.game.physics.components.HitboxComponent;
 import com.csse3200.game.physics.components.PhysicsComponent;
 import com.csse3200.game.rendering.RenderService;
 import com.csse3200.game.services.GameTime;
+import com.csse3200.game.services.ResourceService;
 import com.csse3200.game.services.ServiceLocator;
 import com.csse3200.game.services.TimeService;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +40,7 @@ class MultiDropComponentTest {
     private TimeService timeService;
     private int initialEntityCount;
     private MultiDropComponent multiDropComponent;
+    String[] texturePaths = {"images/dont_delete_test_image.png"};
 
     private Entity createDummyItem() {
         return new Entity(EntityType.DUMMY)
@@ -94,6 +96,8 @@ class MultiDropComponentTest {
 
     @BeforeEach
     void beforeEach() {
+        ServiceLocator.registerResourceService(new ResourceService());
+        ServiceLocator.getResourceService().loadTextures(texturePaths);
         ServiceLocator.registerPhysicsService(new PhysicsService());
         ServiceLocator.registerEntityService(new EntityService());
         ServiceLocator.registerRenderService(new RenderService());
@@ -127,6 +131,7 @@ class MultiDropComponentTest {
         ServiceLocator.registerTimeSource(gameTime);
         timeService = new TimeService();
         ServiceLocator.registerTimeService(timeService);
+        ServiceLocator.getResourceService().loadAll();
         initialEntityCount = getDummyEntityCount();
     }
 

--- a/source/core/src/test/com/csse3200/game/components/npc/MultiDropComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/npc/MultiDropComponentTest.java
@@ -46,7 +46,7 @@ class MultiDropComponentTest {
                 .addComponent(new HitboxComponent().setLayer(PhysicsLayer.ITEM))
                 .addComponent(new ItemActions())
                 .addComponent(new ItemComponent("dummy", ItemType.FERTILISER,
-                        new Texture("images/dont_delete_test_image.png")));
+                        "images/dont_delete_test_image.png"));
     }
 
     private Entity createDummyEntity() {

--- a/source/core/src/test/com/csse3200/game/components/npc/TamingTest.java
+++ b/source/core/src/test/com/csse3200/game/components/npc/TamingTest.java
@@ -38,7 +38,7 @@ public class TamingTest {
         for (int index = 0; index < 4; index++) {
             foodEntity = new Entity(EntityType.ITEM);
             ItemComponent fooditem = new ItemComponent("AFood", ItemType.ANIMAL_FOOD,
-                    new Texture("images/tool_shovel.png")); //texture is just used as a placeholder.
+                    "images/tool_shovel.png"); //texture is just used as a placeholder.
             foodEntity.addComponent(fooditem);
             foodEntity.addComponent(fooditem);
             foodEntity.addComponent(fooditem);

--- a/source/core/src/test/com/csse3200/game/components/npc/TamingTest.java
+++ b/source/core/src/test/com/csse3200/game/components/npc/TamingTest.java
@@ -6,8 +6,12 @@ import static org.mockito.Mockito.spy;
 
 import java.util.ArrayList;
 
+import com.csse3200.game.areas.terrain.GameMap;
+import com.csse3200.game.missions.MissionManager;
+import com.csse3200.game.services.GameTime;
 import com.csse3200.game.services.ResourceService;
 import com.csse3200.game.services.ServiceLocator;
+import com.csse3200.game.services.TimeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +40,9 @@ public class TamingTest {
         ServiceLocator.registerResourceService(new ResourceService());
         ServiceLocator.getResourceService().loadTextures(texturePaths);
         ServiceLocator.getResourceService().loadAll();
+        ServiceLocator.registerMissionManager(new MissionManager());
+        ServiceLocator.registerTimeSource(new GameTime());
+        ServiceLocator.registerTimeService(new TimeService());
 
         playerInventory = new InventoryComponent(new ArrayList<>());
         playerInvSpy = spy(playerInventory);

--- a/source/core/src/test/com/csse3200/game/components/npc/TamingTest.java
+++ b/source/core/src/test/com/csse3200/game/components/npc/TamingTest.java
@@ -12,6 +12,8 @@ import com.csse3200.game.services.GameTime;
 import com.csse3200.game.services.ResourceService;
 import com.csse3200.game.services.ServiceLocator;
 import com.csse3200.game.services.TimeService;
+import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,9 +42,9 @@ public class TamingTest {
         ServiceLocator.registerResourceService(new ResourceService());
         ServiceLocator.getResourceService().loadTextures(texturePaths);
         ServiceLocator.getResourceService().loadAll();
-        ServiceLocator.registerMissionManager(new MissionManager());
         ServiceLocator.registerTimeSource(new GameTime());
         ServiceLocator.registerTimeService(new TimeService());
+        ServiceLocator.registerMissionManager(new MissionManager());
 
         playerInventory = new InventoryComponent(new ArrayList<>());
         playerInvSpy = spy(playerInventory);
@@ -58,6 +60,11 @@ public class TamingTest {
             foodEntity.addComponent(fooditem);
             playerInvSpy.addItem(foodEntity);
         }
+    }
+
+    @AfterEach
+    void clear() {
+        ServiceLocator.clear();
     }
 
     @Test

--- a/source/core/src/test/com/csse3200/game/components/npc/TamingTest.java
+++ b/source/core/src/test/com/csse3200/game/components/npc/TamingTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.spy;
 
 import java.util.ArrayList;
 
+import com.csse3200.game.services.ResourceService;
+import com.csse3200.game.services.ServiceLocator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,9 +29,14 @@ public class TamingTest {
     private InventoryComponent playerInvSpy;
     private Entity foodEntity;
     private Entity nonFood;
+    String[] texturePaths = {"images/tool_shovel.png"};
 
     @BeforeEach
     void beforeEach() {
+        ServiceLocator.registerResourceService(new ResourceService());
+        ServiceLocator.getResourceService().loadTextures(texturePaths);
+        ServiceLocator.getResourceService().loadAll();
+
         playerInventory = new InventoryComponent(new ArrayList<>());
         playerInvSpy = spy(playerInventory);
         player = new Entity().addComponent(playerInvSpy);

--- a/source/core/src/test/com/csse3200/game/components/player/InventoryComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/player/InventoryComponentTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.spy;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.csse3200.game.services.ResourceService;
+import com.csse3200.game.services.ServiceLocator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,6 +32,9 @@ class InventoryComponentTest {
 
   @BeforeEach
   public void setUp() {
+    ServiceLocator.registerResourceService(new ResourceService());
+    ServiceLocator.getResourceService().loadTextures(new String[] {"images/tool_shovel.png"});
+    ServiceLocator.getResourceService().loadAll();
     // Set up the inventory with two initial items
     List<Entity> items = new ArrayList<>();
     inventoryComponent = spy(new InventoryComponent(new ArrayList<>()));

--- a/source/core/src/test/com/csse3200/game/components/player/InventoryComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/player/InventoryComponentTest.java
@@ -40,9 +40,9 @@ class InventoryComponentTest {
 //    items.put(item1.getComponent(ItemComponent.class).getItemName(),item1);
 //    items.put(item2.getComponent(ItemComponent.class).getItemName(),item2);
     ItemComponent itemComponent1 = new ItemComponent("itemTest1", ItemType.HOE,
-            new Texture("images/tool_shovel.png")); // Texture is not used...
+            "images/tool_shovel.png"); // Texture is not used...
     ItemComponent itemComponent2 = new ItemComponent("itemTest2", ItemType.SCYTHE,
-            new Texture("images/tool_shovel.png")); // Texture is not used...
+            "images/tool_shovel.png"); // Texture is not used...
     item1.addComponent(itemComponent1);
     item2.addComponent(itemComponent2);
     inventoryComponent.addItem(item1);
@@ -84,7 +84,7 @@ class InventoryComponentTest {
     // Create a new item
     Entity newItem = new Entity(EntityType.ITEM);
     ItemComponent itemComponent3 = new ItemComponent("itemTest3", ItemType.SCYTHE,
-            new Texture("images/tool_shovel.png")); // Texture is not used...
+            "images/tool_shovel.png"); // Texture is not used...
     // Add the new item to the inventory
     newItem.addComponent(itemComponent3);
     assertTrue(inventoryComponent.addItem(newItem));
@@ -100,7 +100,7 @@ class InventoryComponentTest {
     // Remove an item from the inventory
     Entity newItem = new Entity(EntityType.ITEM);
     ItemComponent itemComponent3 = new ItemComponent("itemTest3", ItemType.SCYTHE,
-            new Texture("images/tool_shovel.png")); // Texture is not used...
+            "images/tool_shovel.png"); // Texture is not used...
     // Add the new item to the inventory
     newItem.addComponent(itemComponent3);
     if(inventoryComponent.getItemCount(item1) == 0){

--- a/source/core/src/test/com/csse3200/game/components/player/InventoryHotkeyTest.java
+++ b/source/core/src/test/com/csse3200/game/components/player/InventoryHotkeyTest.java
@@ -45,7 +45,7 @@ public class InventoryHotkeyTest {
             String[] itemNames = {"Hoe","Hoe1","Hoe2","Hoe3","Hoe4","Hoe5","Hoe6","Hoe7","Hoe8","Hoe9","Hoe10"};
             List<Entity> items = new ArrayList<>();
             for (int i = 0; i < itemNames.length;) {
-                items.add(new Entity().addComponent(new ItemComponent(itemNames[i++], ItemType.HOE, new Texture("images/tool_shovel.png"))));
+                items.add(new Entity().addComponent(new ItemComponent(itemNames[i++], ItemType.HOE, "images/tool_shovel.png")));
             }
             inventoryComponent.setInventory(items);
         }

--- a/source/core/src/test/com/csse3200/game/components/player/InventoryHotkeyTest.java
+++ b/source/core/src/test/com/csse3200/game/components/player/InventoryHotkeyTest.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import com.csse3200.game.services.ResourceService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,76 +26,84 @@ import com.csse3200.game.services.ServiceLocator;
 
 @ExtendWith(GameExtension.class)
 public class InventoryHotkeyTest {
-    private Entity player;
-    private InventoryComponent inventoryComponent;
-    private PlayerActions playerActions;
-    private KeyboardPlayerInputComponent keyboardPlayerInputComponent;
+	private Entity player;
+	private InventoryComponent inventoryComponent;
+	private PlayerActions playerActions;
+	private KeyboardPlayerInputComponent keyboardPlayerInputComponent;
+	String[] texturePaths = {"images/tool_shovel.png"};
 
-    @BeforeEach
-        void initialiseTest() {
-            inventoryComponent = spy(new InventoryComponent(new ArrayList<>()));
-            keyboardPlayerInputComponent = spy(new KeyboardPlayerInputComponent());
-            ServiceLocator.registerInputService(new InputService());
-            playerActions = spy(new PlayerActions());
-            keyboardPlayerInputComponent.setActions(playerActions);
-            player = new Entity()
-                    .addComponent(inventoryComponent)
-                    .addComponent(keyboardPlayerInputComponent)
-                    .addComponent(playerActions);
-            player.create();
-            String[] itemNames = {"Hoe","Hoe1","Hoe2","Hoe3","Hoe4","Hoe5","Hoe6","Hoe7","Hoe8","Hoe9","Hoe10"};
-            List<Entity> items = new ArrayList<>();
-            for (int i = 0; i < itemNames.length;) {
-                items.add(new Entity().addComponent(new ItemComponent(itemNames[i++], ItemType.HOE, "images/tool_shovel.png")));
-            }
-            inventoryComponent.setInventory(items);
-        }
-    @ParameterizedTest
-    @MethodSource({"checkHotkeySelectionTriggerParams"})
-    void checkHotkeySelectionTrigger(int num, String expectedItemName) {
-        player.getEvents().trigger("hotkeySelection",num);
-        verify(inventoryComponent).setHeldItem(num);
-        verify(playerActions).hotkeySelection(num);
-        assertEquals(inventoryComponent.getHeldItem().getComponent(ItemComponent.class).getItemName(), expectedItemName);
-    }
-    private static Stream<Arguments> checkHotkeySelectionTriggerParams() {
-        return Stream.of(
-                arguments(0, "Hoe"),
-                arguments(1, "Hoe1"),
-                arguments(2, "Hoe2"),
-                arguments(3, "Hoe3"),
-                arguments(4, "Hoe4"),
-                arguments(5, "Hoe5"),
-                arguments(6, "Hoe6"),
-                arguments(7, "Hoe7"),
-                arguments(8, "Hoe8"),
-                arguments(9, "Hoe9")
-        );
-    }
-    @ParameterizedTest
-    @MethodSource({"checkKeyboardInputHotkeyParams"})
-        void checkKeyboardInputHotkey(int num) {
-            ServiceLocator.registerInputService(new InputService());
-            keyboardPlayerInputComponent.keyDown(num);
-            verify(keyboardPlayerInputComponent).triggerHotKeySelection(num);
-            verify(inventoryComponent).setHeldItem(num - 8 >= 0 ? num - 8 : 9);
-            verify(playerActions).hotkeySelection(num - 8 >= 0 ? num - 8 : 9);
-            assertEquals(inventoryComponent.getHeldIndex(), num - 8 >= 0 ? num - 8 : 9);
-        }
-        private static Stream<Arguments> checkKeyboardInputHotkeyParams() {
-            return Stream.of(
+	@BeforeEach
+	void initialiseTest() {
+		ServiceLocator.registerResourceService(new ResourceService());
+		ServiceLocator.getResourceService().loadTextures(texturePaths);
+		ServiceLocator.getResourceService().loadAll();
+		inventoryComponent = spy(new InventoryComponent(new ArrayList<>()));
+		keyboardPlayerInputComponent = spy(new KeyboardPlayerInputComponent());
+		ServiceLocator.registerInputService(new InputService());
+		playerActions = spy(new PlayerActions());
+		keyboardPlayerInputComponent.setActions(playerActions);
+		player = new Entity()
+				.addComponent(inventoryComponent)
+				.addComponent(keyboardPlayerInputComponent)
+				.addComponent(playerActions);
+		player.create();
+		String[] itemNames = {"Hoe", "Hoe1", "Hoe2", "Hoe3", "Hoe4", "Hoe5", "Hoe6", "Hoe7", "Hoe8", "Hoe9", "Hoe10"};
+		List<Entity> items = new ArrayList<>();
+		for (int i = 0; i < itemNames.length; ) {
+			items.add(new Entity().addComponent(new ItemComponent(itemNames[i++], ItemType.HOE, "images/tool_shovel.png")));
+		}
+		inventoryComponent.setInventory(items);
+	}
 
-                    arguments(8),
-                    arguments(9),
-                    arguments(10),
-                    arguments(11),
-                    arguments(12),
-                    arguments(13),
-                    arguments(14),
-                    arguments(15),
-                    arguments(16),
-                    arguments(7)
+	@ParameterizedTest
+	@MethodSource({"checkHotkeySelectionTriggerParams"})
+	void checkHotkeySelectionTrigger(int num, String expectedItemName) {
+		player.getEvents().trigger("hotkeySelection", num);
+		verify(inventoryComponent).setHeldItem(num);
+		verify(playerActions).hotkeySelection(num);
+		assertEquals(inventoryComponent.getHeldItem().getComponent(ItemComponent.class).getItemName(), expectedItemName);
+	}
 
-            );
-        }
+	private static Stream<Arguments> checkHotkeySelectionTriggerParams() {
+		return Stream.of(
+				arguments(0, "Hoe"),
+				arguments(1, "Hoe1"),
+				arguments(2, "Hoe2"),
+				arguments(3, "Hoe3"),
+				arguments(4, "Hoe4"),
+				arguments(5, "Hoe5"),
+				arguments(6, "Hoe6"),
+				arguments(7, "Hoe7"),
+				arguments(8, "Hoe8"),
+				arguments(9, "Hoe9")
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource({"checkKeyboardInputHotkeyParams"})
+	void checkKeyboardInputHotkey(int num) {
+		ServiceLocator.registerInputService(new InputService());
+		keyboardPlayerInputComponent.keyDown(num);
+		verify(keyboardPlayerInputComponent).triggerHotKeySelection(num);
+		verify(inventoryComponent).setHeldItem(num - 8 >= 0 ? num - 8 : 9);
+		verify(playerActions).hotkeySelection(num - 8 >= 0 ? num - 8 : 9);
+		assertEquals(inventoryComponent.getHeldIndex(), num - 8 >= 0 ? num - 8 : 9);
+	}
+
+	private static Stream<Arguments> checkKeyboardInputHotkeyParams() {
+		return Stream.of(
+
+				arguments(8),
+				arguments(9),
+				arguments(10),
+				arguments(11),
+				arguments(12),
+				arguments(13),
+				arguments(14),
+				arguments(15),
+				arguments(16),
+				arguments(7)
+
+		);
+	}
 }

--- a/source/core/src/test/com/csse3200/game/components/player/ItemPickupComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/player/ItemPickupComponentTest.java
@@ -79,7 +79,7 @@ public class ItemPickupComponentTest {
         pickupItem = new Entity(EntityType.ITEM)
                 .addComponent(new PhysicsComponent())
                 .addComponent(new HitboxComponent().setLayer(PhysicsLayer.ITEM))
-                .addComponent(new ItemComponent("Shovel", ItemType.SHOVEL, new Texture("images/tool_shovel.png")));
+                .addComponent(new ItemComponent("Shovel", ItemType.SHOVEL, "images/tool_shovel.png"));
 
         picker.create();
         pickupItem.create();

--- a/source/core/src/test/com/csse3200/game/components/player/ItemPickupComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/player/ItemPickupComponentTest.java
@@ -62,14 +62,18 @@ public class ItemPickupComponentTest {
         }
     }
 
+    String[] texturePaths = {"images/tool_shovel.png"};
+
     @BeforeEach
     void beforeEach() {
+        ServiceLocator.registerResourceService(new ResourceService());
+        ServiceLocator.getResourceService().loadTextures(texturePaths);
         ServiceLocator.registerPhysicsService(new PhysicsService());
         ServiceLocator.registerInputService(new InputService());
-        ServiceLocator.registerResourceService(new ResourceService());
         ServiceLocator.registerEntityService(new EntityService());
         ServiceLocator.registerRenderService(new RenderService());
         ServiceLocator.registerGameArea(new TestGameArea());
+        ServiceLocator.getResourceService().loadAll();
         /* Create two test entities (one that picks up the other) */
         picker = new Entity()
                 .addComponent(new PhysicsComponent())

--- a/source/core/src/test/com/csse3200/game/components/player/OpenPauseComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/player/OpenPauseComponentTest.java
@@ -27,11 +27,14 @@ class OpenPauseComponentTest {
     Entity player;
     OpenPauseComponent openPauseComponent;
 
+    String[] texturePaths = {"images/PauseMenu/Pause_Overlay.jpg", "images/PauseMenu/Pausenew.jpg"};
     @BeforeEach
     void init() {
         AssetManager assetManager = spy(AssetManager.class);
         ResourceService resourceService = new ResourceService(assetManager);
         ServiceLocator.registerResourceService(resourceService);
+        ServiceLocator.getResourceService().loadTextures(texturePaths);
+        ServiceLocator.getResourceService().loadAll();
         TimeService timeService = new TimeService();
         ServiceLocator.registerTimeService(timeService);
         GameTime gameTime = new GameTime();

--- a/source/core/src/test/com/csse3200/game/components/player/PlayerInventoryTest.java
+++ b/source/core/src/test/com/csse3200/game/components/player/PlayerInventoryTest.java
@@ -10,6 +10,8 @@ import java.util.HashMap;
 
 import com.csse3200.game.entities.EntityType;
 import com.badlogic.gdx.math.Vector2;
+import com.csse3200.game.services.ResourceService;
+import com.csse3200.game.services.ServiceLocator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,8 +28,14 @@ public class PlayerInventoryTest {
     private InventoryComponent inventoryComponent;
     private Entity item1;
     private Entity item2;
+
+    String[] texturePaths = {"images/tool_shovel.png"};
     @BeforeEach
     void initialiseTest() {
+        ServiceLocator.registerResourceService(new ResourceService());
+        ServiceLocator.getResourceService().loadTextures(texturePaths);
+        ServiceLocator.getResourceService().loadAll();
+
         inventoryComponent = spy(new InventoryComponent(new ArrayList<>()));
         player = new Entity()
                 .addComponent(inventoryComponent);

--- a/source/core/src/test/com/csse3200/game/components/player/PlayerInventoryTest.java
+++ b/source/core/src/test/com/csse3200/game/components/player/PlayerInventoryTest.java
@@ -33,8 +33,8 @@ public class PlayerInventoryTest {
                 .addComponent(inventoryComponent);
         player.create();
         player.getEvents().addListener("use", inventoryComponent::useItem);
-        item1 = new Entity(EntityType.ITEM).addComponent(new ItemComponent("Hoe", ItemType.HOE, new Texture("images/tool_shovel.png")));
-        item2 = new Entity(EntityType.ITEM).addComponent(new ItemComponent("Scythe",ItemType.SCYTHE, new Texture("images/tool_shovel.png")));
+        item1 = new Entity(EntityType.ITEM).addComponent(new ItemComponent("Hoe", ItemType.HOE, "images/tool_shovel.png"));
+        item2 = new Entity(EntityType.ITEM).addComponent(new ItemComponent("Scythe",ItemType.SCYTHE, "images/tool_shovel.png"));
     }
 
     @Test
@@ -74,7 +74,7 @@ public class PlayerInventoryTest {
     // checks if using an item decreases the count of perishable items by 1, else removes the item.
     @Test
     void useItemShouldRemovePerishableItem() {
-        Entity perishable = new Entity(EntityType.ITEM).addComponent(new ItemComponent("TestItem",ItemType.FERTILISER, new Texture("images/tool_shovel.png"),true));
+        Entity perishable = new Entity(EntityType.ITEM).addComponent(new ItemComponent("TestItem",ItemType.FERTILISER, "images/tool_shovel.png",true));
 
         inventoryComponent.addItem(perishable);
         inventoryComponent.setHeldItem(0);
@@ -89,7 +89,7 @@ public class PlayerInventoryTest {
     // checks if using an item does not remove a nonperishable item.
     @Test
     void useItemShouldNotRemoveNonperishableItem() {
-        Entity item = new Entity(EntityType.ITEM).addComponent(new ItemComponent("TestItem",ItemType.HOE, new Texture("images/tool_shovel.png"),false));
+        Entity item = new Entity(EntityType.ITEM).addComponent(new ItemComponent("TestItem",ItemType.HOE, "images/tool_shovel.png",false));
 
         inventoryComponent.addItem(item);
         inventoryComponent.setHeldItem(0);

--- a/source/core/src/test/com/csse3200/game/components/tasks/MoveToPlantTaskTest.java
+++ b/source/core/src/test/com/csse3200/game/components/tasks/MoveToPlantTaskTest.java
@@ -11,6 +11,7 @@ import com.csse3200.game.physics.components.PhysicsMovementComponent;
 import com.csse3200.game.rendering.DebugRenderer;
 import com.csse3200.game.rendering.RenderService;
 import com.csse3200.game.services.GameTime;
+import com.csse3200.game.services.ResourceService;
 import com.csse3200.game.services.ServiceLocator;
 import com.csse3200.game.services.TimeService;
 import com.csse3200.game.utils.math.Vector2Utils;

--- a/source/core/src/test/com/csse3200/game/components/tasks/TamedFollowTaskTest.java
+++ b/source/core/src/test/com/csse3200/game/components/tasks/TamedFollowTaskTest.java
@@ -8,6 +8,7 @@ import com.csse3200.game.ai.tasks.AITaskComponent;
 import com.csse3200.game.components.player.InventoryComponent;
 import com.csse3200.game.entities.EntityType;
 import com.csse3200.game.extensions.GameExtension;
+import com.csse3200.game.services.ResourceService;
 import com.csse3200.game.utils.math.Vector2Utils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import com.csse3200.game.services.GameTime;
 import com.csse3200.game.services.ServiceLocator;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.io.Serial;
 import java.util.ArrayList;
 
 @ExtendWith(GameExtension.class)
@@ -36,9 +38,14 @@ public class TamedFollowTaskTest {
     private Entity target;
     private InventoryComponent targetInventory;
     private InventoryComponent targetInvSpy;
+    String[] texturePaths = {"images/animals/egg.png"};
 
     @BeforeEach
     void beforeEach() {
+        ServiceLocator.registerResourceService(new ResourceService());
+        ServiceLocator.getResourceService().loadTextures(texturePaths);
+        ServiceLocator.getResourceService().loadAll();
+
         targetInventory = new InventoryComponent(new ArrayList<>());
         targetInvSpy = spy(targetInventory);
         target = new Entity().addComponent(targetInvSpy);

--- a/source/core/src/test/com/csse3200/game/components/tasks/TamedFollowTaskTest.java
+++ b/source/core/src/test/com/csse3200/game/components/tasks/TamedFollowTaskTest.java
@@ -45,7 +45,7 @@ public class TamedFollowTaskTest {
         target.create();
 
         foodEntity = new Entity(EntityType.ITEM);
-        fooditem = new ItemComponent("AFood", ItemType.ANIMAL_FOOD, new Texture("images/animals/egg.png"));
+        fooditem = new ItemComponent("AFood", ItemType.ANIMAL_FOOD, "images/animals/egg.png");
         //texture is just used as a placeholder.
         //add Animal's favourite food to player/target's spy inventory. (Will be the only item in inventory).
         foodEntity.addComponent(fooditem);


### PR DESCRIPTION
# Overview

Rework of #493 

- Currently redundant asset objects are being created (`Texture`, `Skin`, etc.)
- Most of these assets have already been loaded in in the `loadAssets()` method in the `SpaceGameArea` class
- These assets should be accessed via the `AssetManager` in the `ResourceService` so that they can be loaded asynchronously loaded during game startup, and reuse assets
- This will reduce the work done by the garbage collector as assets can be reused

Putting a couple teams as reviewers so that they are aware of changes ui/components.
- Team 1 - Change to `ItemComponent` to use texture path
- Team 1 - Changes overloaded constructor for `ItemComponent`
- Team 5 - Using skin from `ResourceService`
- Team 8 - Changes to inventory display stuff and usage of `ResourceService` for item slot stuff

**TLDR** - 99.9% of this PR is changing:
- `new Texture(path)` to `ServiceLocator.getResourceService.getAsset(path, Texture.class)`
- `new Skin(path)` to `ServiceLocator.getResourceService.getAsset(path, Skin.class)`

Reformatted a couple of files on accident so sorry for the large diff :( - Intellij does it's thing when reformatting